### PR TITLE
feat: Search 페이지 다른 컴포넌트로 이동/무한 스크롤

### DIFF
--- a/src/assets/css/module/search/Search.css
+++ b/src/assets/css/module/search/Search.css
@@ -1,13 +1,24 @@
+.search-container {
+  display: flex;
+  flex-direction: column;
+  height: 90vh;
+}
+
 .list-container {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 8px 5px;
   margin-top: 12px;
+  overflow: auto;
 }
 
 .icon-title {
   display: flex;
   gap: 4px;
   align-items: center;
+}
+
+.scroll {
+
 }

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -28,7 +28,7 @@ const Footer = () => {
             </Link>
           </Col>
           <Col>
-            <Link to="/Footer4">
+            <Link to="/search">
               <FaSearch size={24} />
               <div>검색</div>
             </Link>

--- a/src/components/common/SearchBar.jsx
+++ b/src/components/common/SearchBar.jsx
@@ -1,4 +1,8 @@
+import { useEffect, useRef } from "react";
 import { Button, Form, InputGroup } from "react-bootstrap";
+import { useSearchParams } from "react-router-dom";
+
+export const PARAM_KEY_SEARCH_KEYWORD = "search-keyword";
 
 /**
  * @param {{
@@ -8,11 +12,22 @@ import { Button, Form, InputGroup } from "react-bootstrap";
  * @returns JSX.Element
  */
 export default function SearchBar({typeCallback, searchCallback}) {
+  const [queryParams, setQueryParams] = useSearchParams();
+
+  const searchKeywordInputRef = useRef(null);
+
+  useEffect(() => {
+    if (queryParams.has(PARAM_KEY_SEARCH_KEYWORD)) {
+      searchCallback();
+      searchKeywordInputRef.current.value = queryParams.get(PARAM_KEY_SEARCH_KEYWORD);
+    }
+  }, []);
 
   return (
     <InputGroup className="mb-3">
       <Form.Control
           onChange={(e) => typeCallback(e.target.value)}
+          ref={searchKeywordInputRef}
       />
       <Button type="button" onClick={() => searchCallback()}>검색</Button>
     </InputGroup>

--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import $ from "jquery";
-import SearchBar from "../../components/common/SearchBar";
+import SearchBar, { PARAM_KEY_SEARCH_KEYWORD } from "../../components/common/SearchBar";
 import FetchTypeToggle from "./component/FetchTypeToggle";
 import axios_api from "../../lib/axios_api";
 import { MAIN_API_URL } from "../../util/constants";
@@ -8,6 +8,7 @@ import { is2xxStatus, is4xxStatus } from "../../util/statusCodeUtil";
 import { getBuildingMarkerHtml, getPlaceSearchMarkerHtml } from "./contant/markerHtml";
 import "../../assets/css/module/map/BMap.css";
 import Footer from "../../components/common/Footer";
+import { useSearchParams } from "react-router-dom";
 
 const naver = window.naver;
 
@@ -27,7 +28,10 @@ const buildingFetchChecked = {
 }
 
 export default function BMap() {
-  const [placeSearchKeyword, setPlaceSearchKeyword] = useState("");
+  const [queryParams, setQueryParams] = useSearchParams();
+
+  const [placeSearchKeyword, setPlaceSearchKeyword] =
+      useState(queryParams.has(PARAM_KEY_SEARCH_KEYWORD) ? queryParams.get(PARAM_KEY_SEARCH_KEYWORD) : "");
   const [currentPosition, setCurrentPosition] = useState(undefined);
   const [subscriptionChecked, setSubscriptionChecked] = useState(true);
   const [popBuildingChecked, setPopBuildingChecked] = useState(true);
@@ -106,7 +110,7 @@ export default function BMap() {
     <div className="container map-container">
       <SearchBar
         typeCallback={(text) => setPlaceSearchKeyword(text)}
-        searchCallback={() => searchPlaceList(placeSearchKeyword, onFetchPlace)}
+        searchCallback={() => searchPlaceList(placeSearchKeyword, onFetchPlace, queryParams, setQueryParams)}
       />
       <div id="map">
         <button
@@ -132,7 +136,9 @@ export default function BMap() {
  * @param {string} searchKeyword 
  * @param {(places: any) => void} callback 
  */
-function searchPlaceList(searchKeyword, callback) {
+function searchPlaceList(searchKeyword, callback, queryParams, setQueryParams) {
+  queryParams.set(PARAM_KEY_SEARCH_KEYWORD, searchKeyword);
+  setQueryParams(queryParams);
   axios_api.get(`${MAIN_API_URL}/places/search`, {
     params: {
       placeName: searchKeyword

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import SearchBar from "../../components/common/SearchBar";
+import SearchBar, { PARAM_KEY_SEARCH_KEYWORD } from "../../components/common/SearchBar";
 import SearchModeTab, { modes } from "./component/SearchModeTab";
 import FeedSearchResult from "./component/FeedSearchResult";
 import BuildingSearchResult from "./component/BuildingSearchResult";
@@ -10,10 +10,17 @@ import searchBuilding from "./axios/searchBuilding";
 import searchChatroom from "./axios/searchChatroom";
 import searchMember from "./axios/searchMember";
 import "../../assets/css/module/search/Search.css";
+import { useSearchParams } from "react-router-dom";
+
+
+const PARAM_KEY_SEARCH_MODE = "search-mode";
 
 export default function Search() {
-  const [searchKeyword, setSearchKeyword] = useState("");
-  const [currentSearchMode, setCurrentSearchMode] = useState(modes.INTEGRATION);
+  const [queryParams, setQueryParams] = useSearchParams();
+  
+  const [searchKeyword, setSearchKeyword] = useState(queryParams.has(PARAM_KEY_SEARCH_KEYWORD) ? queryParams.get(PARAM_KEY_SEARCH_KEYWORD) : "");
+  const [currentSearchMode, setCurrentSearchMode] =
+      useState(queryParams.has(PARAM_KEY_SEARCH_MODE) ? parseInt(queryParams.get(PARAM_KEY_SEARCH_MODE)) : modes.INTEGRATION);
   const [searchResult, setSearchResult] = useState({
     2: [],
     3: [],
@@ -53,19 +60,24 @@ export default function Search() {
 
   function onSearch() {
     searchFunction(searchKeyword, page, (data) => {
-      console.log(data);
-      console.log(currentSearchMode);
+      queryParams.set(PARAM_KEY_SEARCH_KEYWORD, searchKeyword);
+      setQueryParams(queryParams);
       const newSearchResult = {...searchResult};
       newSearchResult[currentSearchMode] = data;
-      console.log(newSearchResult);
       setSearchResult(newSearchResult);
     }, SAMPLE_MEMBER);
+  }
+
+  function onModeChange(mode) {
+    setCurrentSearchMode(mode);
+    queryParams.set(PARAM_KEY_SEARCH_MODE, mode);
+    setQueryParams(queryParams);
   }
 
   return (
     <div className="container">
       <SearchBar typeCallback={(text) => setSearchKeyword(text)} searchCallback={onSearch} />
-      <SearchModeTab currentSearchMode={currentSearchMode} onModeChange={(mode) => setCurrentSearchMode(mode)} />
+      <SearchModeTab currentSearchMode={currentSearchMode} onModeChange={onModeChange} />
       {component}
     </div>
   );

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -1,16 +1,17 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import SearchBar, { PARAM_KEY_SEARCH_KEYWORD } from "../../components/common/SearchBar";
 import SearchModeTab, { modes } from "./component/SearchModeTab";
 import FeedSearchResult from "./component/FeedSearchResult";
 import BuildingSearchResult from "./component/BuildingSearchResult";
 import ChatroomSearchResult from "./component/ChatroomSearchResult";
 import MemberSearchResult from "./component/MemberSearchResult";
-import searchFeed from "./axios/searchFeed";
-import searchBuilding from "./axios/searchBuilding";
-import searchChatroom from "./axios/searchChatroom";
-import searchMember from "./axios/searchMember";
+import searchFeed, { isFeedSearchResultEmpty } from "./axios/searchFeed";
+import searchBuilding, { isBuildingSearchResultEmpty } from "./axios/searchBuilding";
+import searchChatroom, { isChatroomSearchResultEmpty } from "./axios/searchChatroom";
+import searchMember, { isMemberSearchResultEmpty } from "./axios/searchMember";
 import "../../assets/css/module/search/Search.css";
 import { useSearchParams } from "react-router-dom";
+import Footer from "../../components/common/Footer";
 
 
 const PARAM_KEY_SEARCH_MODE = "search-mode";
@@ -21,16 +22,29 @@ export default function Search() {
   const [searchKeyword, setSearchKeyword] = useState(queryParams.has(PARAM_KEY_SEARCH_KEYWORD) ? queryParams.get(PARAM_KEY_SEARCH_KEYWORD) : "");
   const [currentSearchMode, setCurrentSearchMode] =
       useState(queryParams.has(PARAM_KEY_SEARCH_MODE) ? parseInt(queryParams.get(PARAM_KEY_SEARCH_MODE)) : modes.INTEGRATION);
-  const [searchResult, setSearchResult] = useState({
-    2: [],
-    3: [],
-    4: {},
-    5: {}
-  });
+  const [searchResult, setSearchResult] = useState();
   const [page, setPage] = useState(1);
-  
-  // TODO
+
+  const observer = useRef(undefined);
+
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
   const SAMPLE_MEMBER = "member_2";
+
+  const lastFeedElementRef = useCallback((node) => {
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+    observer.current = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore && !loading) {
+        setPage((prevPage) => prevPage + 1);
+      }
+    });
+    if (node) {
+      observer.current.observe(node);
+    }
+  }, [hasMore]);
 
   console.log(searchResult);
 
@@ -38,47 +52,97 @@ export default function Search() {
   let component;
   switch (currentSearchMode) {
     case modes.FEED:
-      component = <FeedSearchResult key="feed-search-result" pageCallback={() => setPage(page + 1)} searchResult={searchResult[modes.FEED]} />;
-      searchFunction = searchFeed;
+      component = <FeedSearchResult
+          key="feed-search-result"
+          searchResult={searchResult}
+          infScrollTargetRef={lastFeedElementRef} />;
+      searchFunction = searchFeed
       break;
     case modes.BUILDING:
-      component = <BuildingSearchResult key="building-search-result" pageCallback={() => setPage(page + 1)} searchResult={searchResult[modes.BUILDING]} />;
-      searchFunction = searchBuilding;
+      component = <BuildingSearchResult
+          key="building-search-result"
+          searchResult={searchResult}
+          infScrollTargetRef={lastFeedElementRef} />;
+      searchFunction = searchBuilding
       break;
     case modes.CHATROOM:
-      component = <ChatroomSearchResult key="chatroom-search-result" pageCallback={() => setPage(page + 1)} searchResult={searchResult[modes.CHATROOM]} />;
+      component = <ChatroomSearchResult
+          key="chatroom-search-result"
+          searchResult={searchResult}
+          infScrollTargetRef={lastFeedElementRef} />;
       searchFunction = searchChatroom
       break;
     case modes.MEMBER:
-      component = <MemberSearchResult key="member-search-result" pageCallback={() => setPage(page + 1)} searchResult={searchResult[modes.MEMBER]} />;
-      searchFunction = searchMember;
+      component = <MemberSearchResult
+          key="member-search-result"
+          searchResult={searchResult}
+          infScrollTargetRef={lastFeedElementRef} />;
+      searchFunction = searchMember
       break;
     default:
       component = <p>통합검색창</p>;
-      searchFunction = () => {};
+      searchFunction = () => {}
   }
 
-  function onSearch() {
-    searchFunction(searchKeyword, page, (data) => {
-      queryParams.set(PARAM_KEY_SEARCH_KEYWORD, searchKeyword);
-      setQueryParams(queryParams);
-      const newSearchResult = {...searchResult};
-      newSearchResult[currentSearchMode] = data;
-      setSearchResult(newSearchResult);
-    }, SAMPLE_MEMBER);
+  useEffect(() => {
+    if (hasMore && !loading && page !== 1) {
+      setLoading(true);
+      
+      searchFunction(searchKeyword, page, (data) => {
+        if (!data || data.length === 0) {
+          setHasMore(false);
+          return;
+        }
+        setHasMore(true);
+
+        let newSearchResult;
+        if (searchResult) {
+          newSearchResult = [...searchResult, ...data];
+        } else {
+          newSearchResult = [...data];
+        }
+        setSearchResult(newSearchResult);
+        setLoading(false);;
+      }, SAMPLE_MEMBER);
+    }
+  }, [page]);
+
+  function onSearchBtnClick() {
+    if (!loading) {
+      searchFunction(searchKeyword, page, (data) => {
+        queryParams.set(PARAM_KEY_SEARCH_KEYWORD, searchKeyword);
+        setPage(1);
+        setQueryParams(queryParams);
+        console.log(data);
+        if (!data || data.length === 0) {
+          setHasMore(false);
+          return;
+        }
+        const newSearchResult = [...data];
+        setSearchResult(newSearchResult);
+        setLoading(false);
+      }, SAMPLE_MEMBER);
+    }
   }
 
   function onModeChange(mode) {
     setCurrentSearchMode(mode);
+    setPage(1);
+    setSearchResult(null);
+    setHasMore(true);
+    setLoading(false);
+    queryParams.delete(PARAM_KEY_SEARCH_KEYWORD);
+    setQueryParams(queryParams);
     queryParams.set(PARAM_KEY_SEARCH_MODE, mode);
     setQueryParams(queryParams);
   }
 
   return (
-    <div className="container">
-      <SearchBar typeCallback={(text) => setSearchKeyword(text)} searchCallback={onSearch} />
+    <div className="container search-container">
+      <SearchBar typeCallback={(text) => setSearchKeyword(text)} searchCallback={onSearchBtnClick} />
       <SearchModeTab currentSearchMode={currentSearchMode} onModeChange={onModeChange} />
       {component}
+      <Footer />
     </div>
   );
 }

--- a/src/pages/search/axios/searchBuilding.js
+++ b/src/pages/search/axios/searchBuilding.js
@@ -1,10 +1,14 @@
 import axios_api from "../../../lib/axios_api";
 
 export default function searchBuilding(searchKeyword, page, callback) {
-    axios_api.get("/buildingProfile/searchBuilding", {
-        params: {
-            searchKeyword,
-            page
-        }
-    }).then((response) => callback(response.data));
+  axios_api.get("/buildingProfile/searchBuilding", {
+    params: {
+      searchKeyword,
+      page
+    }
+  }).then((response) => callback(response.data));
+}
+
+export function isBuildingSearchResultEmpty(data) {
+  return data.length === 0;
 }

--- a/src/pages/search/axios/searchChatroom.js
+++ b/src/pages/search/axios/searchChatroom.js
@@ -6,5 +6,9 @@ export default function searchChatroom(searchKeyword, page, callback) {
       searchKeyword,
       page
     }
-  }).then((response) => callback(response.data));
+  }).then((response) => callback(response.data.content));
+}
+
+export function isChatroomSearchResultEmpty(data) {
+  return data.content.length === 0;
 }

--- a/src/pages/search/axios/searchFeed.js
+++ b/src/pages/search/axios/searchFeed.js
@@ -10,3 +10,8 @@ export default function searchFeed(searchKeyword, page, callback) {
       callback(response.data);
     })
 }
+
+export function isFeedSearchResultEmpty(data) {
+  console.log(data);
+  return data.length === 0;
+}

--- a/src/pages/search/axios/searchMember.js
+++ b/src/pages/search/axios/searchMember.js
@@ -7,5 +7,9 @@ export default function searchMember(searchKeyword, page, callback, requesterId)
       searchKeyword,
       page
     }
-  }).then((response) => callback(response.data));
+  }).then((response) => callback(response.data.info.content));
+}
+
+export function isMemberSearchResultEmpty(data) {
+  return data.info.content.length === 0;
 }

--- a/src/pages/search/component/BuildingSearchResult.jsx
+++ b/src/pages/search/component/BuildingSearchResult.jsx
@@ -1,14 +1,16 @@
+import { useNavigate } from "react-router-dom";
 import "../../../assets/css/module/search/component/BuildingSearchResult.css";
 
 /**
  * @param {{
  *   searchResult: {
- *     buildingName: "string",
- *     roadAddr: "string",
- *     feedAiSummary: "string",
+ *     buildingId: number;
+ *     buildingName: string;
+ *     roadAddr: string;
+ *     feedAiSummary: string;
  *     liveliestChatroomDto: {
- *       chatroomName: "string",
- *       liveliness: "string"
+ *       chatroomName: string;
+ *       liveliness: string;
  *     }
  *   }[],
  *   pageCallback: () => void
@@ -25,6 +27,7 @@ export default function BuildingSearchResult({
         searchResult.map((data, idx) =>
             <BuildingSearchResultItem
                 key={`building-item-${idx}`}
+                buildingId={data.buildingId}
                 buildingName={data.buildingName}
                 liveliestChatroomDto={data.liveliestChatroomDto}
                 roadAddr={data.roadAddr}
@@ -38,27 +41,33 @@ export default function BuildingSearchResult({
 /**
  * 
  * @param {{
- *   buildingName: "string",
- *   roadAddr: "string",
- *   feedAiSummary: "string",
+ *   buildingId: number;
+ *   buildingName: string;
+ *   roadAddr: string;
+ *   feedAiSummary: string;
  *   liveliestChatroomDto: {
- *     chatroomName: "string",
- *     liveliness: "string"
+ *     chatroomName: string;
+ *     liveliness: string;
  *   }
  * }} props 
 */
 function BuildingSearchResultItem({
+  buildingId,
   buildingName,
   roadAddr,
   feedAiSummary,
   liveliestChatroomDto
 }) {
+  const navigate = useNavigate();
   console.log(buildingName);
   console.log(roadAddr);
   console.log(feedAiSummary);
   console.log(liveliestChatroomDto);
   return (
-    <div className="building-item-container item-container">
+    <div
+        className="building-item-container item-container"
+        onClick={() => navigate(`/getBuildingProfile/${buildingId}`)}
+    >
       <h3>{buildingName}</h3>
       <div>
         <div className="icon-title">

--- a/src/pages/search/component/BuildingSearchResult.jsx
+++ b/src/pages/search/component/BuildingSearchResult.jsx
@@ -13,18 +13,18 @@ import "../../../assets/css/module/search/component/BuildingSearchResult.css";
  *       liveliness: string;
  *     }
  *   }[],
- *   pageCallback: () => void
+ *   infScrollTargetRef
  * }} props
  */
 export default function BuildingSearchResult({
   searchResult,
-  pageCallback
+  infScrollTargetRef
 }) {
 
   return (
-    <div className="list-container">
+    <div className="scroll list-container">
       {
-        searchResult.map((data, idx) =>
+        searchResult && searchResult.map((data, idx) =>
             <BuildingSearchResultItem
                 key={`building-item-${idx}`}
                 buildingId={data.buildingId}
@@ -32,6 +32,7 @@ export default function BuildingSearchResult({
                 liveliestChatroomDto={data.liveliestChatroomDto}
                 roadAddr={data.roadAddr}
                 feedAiSummary={data.feedAiSummary}
+                infScrollTargetRef={idx + 1 === searchResult.length ? infScrollTargetRef : null}
             />)
       }
     </div>
@@ -56,7 +57,8 @@ function BuildingSearchResultItem({
   buildingName,
   roadAddr,
   feedAiSummary,
-  liveliestChatroomDto
+  liveliestChatroomDto,
+  infScrollTargetRef
 }) {
   const navigate = useNavigate();
   console.log(buildingName);
@@ -67,6 +69,7 @@ function BuildingSearchResultItem({
     <div
         className="building-item-container item-container"
         onClick={() => navigate(`/getBuildingProfile/${buildingId}`)}
+        ref={infScrollTargetRef}
     >
       <h3>{buildingName}</h3>
       <div>

--- a/src/pages/search/component/BuildingSearchResult.jsx
+++ b/src/pages/search/component/BuildingSearchResult.jsx
@@ -1,28 +1,4 @@
-import { useEffect, useState } from "react";
 import "../../../assets/css/module/search/component/BuildingSearchResult.css";
-
-const SAMPLE_DATA = [
-  {
-    buildingName: "name1",
-    liveliestChatroomName: "chatroom1",
-    roadAddress: "서울시 영등포구"
-  },
-  {
-    buildingName: "name2",
-    liveliestChatroomName: "chatroom2",
-    roadAddress: "서울시 영등포구"
-  },
-  {
-    buildingName: "name3",
-    liveliestChatroomName: "chatroom3",
-    roadAddress: "서울시 영등포구"
-  },
-  {
-    buildingName: "name4",
-    liveliestChatroomName: "chatroom4",
-    roadAddress: "서울시 영등포구"
-  }
-]
 
 /**
  * @param {{

--- a/src/pages/search/component/ChatroomSearchResult.jsx
+++ b/src/pages/search/component/ChatroomSearchResult.jsx
@@ -17,19 +17,19 @@ import "../../../assets/css/module/search/component/ChatroomSearchResult.css";
  *       chatroomType: string;
  *       chatroomMinTemp: number;
  *     }[]
- *   },
- *   pageCallback: () => void;
+ *   };
+ *   infScrollTargetRef;
  * }} props
  */
 export default function ChatroomSearchResult({
   searchResult,
-  pageCallback
+  infScrollTargetRef
 }) {
   console.log(searchResult);
   return (
-    <div className="list-container">
+    <div className="scroll list-container">
       {
-        searchResult && searchResult.content && searchResult.content.map((data, idx) => (
+        searchResult && searchResult.map((data, idx) => (
           <CharoomSearchResultItem
             key={`chatroom-item-${idx}`}
             chatroomId={data.chatroomId}
@@ -40,6 +40,7 @@ export default function ChatroomSearchResult({
             chatroomCreatorId={data.chatroomCreatorId}
             chatroomType={data.chatroomType}
             chatroomMinTemp={data.chatroomMinTemp}
+            infScrollTargetRef={idx + 1 === searchResult.length ? infScrollTargetRef : null}
           />
         ))
       }
@@ -67,13 +68,15 @@ function CharoomSearchResultItem({
   roadAddr,
   chatroomCreatorId,
   chatroomType,
-  chatroomMinTemp
+  chatroomMinTemp,
+  infScrollTargetRef
 }) {
   const navigate = useNavigate();
   return (
     <div
         className="item-container chatroom-item-container"
         onClick={() => navigate(`/chat/chatroom?chatroomID=${chatroomId}`)}
+        ref={infScrollTargetRef}
     >
       <div className="info">
         <h3>{chatroomName}</h3>

--- a/src/pages/search/component/ChatroomSearchResult.jsx
+++ b/src/pages/search/component/ChatroomSearchResult.jsx
@@ -1,16 +1,4 @@
-import { useEffect, useState } from "react";
 import "../../../assets/css/module/search/component/ChatroomSearchResult.css";
-
-const SAMPLE_DATA = []
-
-for (let i = 0; i <= 5; i++) {
-  SAMPLE_DATA.push({
-    chatroomName: `chatroomName-${i}`,
-    participantCount: i + 13,
-    buildingName: `buildingName-${i}`,
-    roadAddress: `서울시 영등포구`
-  });
-}
 
 /**
  * @param {{

--- a/src/pages/search/component/ChatroomSearchResult.jsx
+++ b/src/pages/search/component/ChatroomSearchResult.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import "../../../assets/css/module/search/component/ChatroomSearchResult.css";
 
 /**
@@ -31,7 +32,7 @@ export default function ChatroomSearchResult({
         searchResult && searchResult.content && searchResult.content.map((data, idx) => (
           <CharoomSearchResultItem
             key={`chatroom-item-${idx}`}
-            chatroomId={data.chatroomID}
+            chatroomId={data.chatroomId}
             chatroomName={data.chatroomName}
             participantCount={data.participantCount}
             buildingName={data.buildingName}
@@ -68,8 +69,12 @@ function CharoomSearchResultItem({
   chatroomType,
   chatroomMinTemp
 }) {
+  const navigate = useNavigate();
   return (
-    <div className="item-container chatroom-item-container">
+    <div
+        className="item-container chatroom-item-container"
+        onClick={() => navigate(`/chat/chatroom?chatroomID=${chatroomId}`)}
+    >
       <div className="info">
         <h3>{chatroomName}</h3>
         <div className="icon-title">

--- a/src/pages/search/component/FeedSearchResult.jsx
+++ b/src/pages/search/component/FeedSearchResult.jsx
@@ -21,19 +21,19 @@ const TEXT_MAX_LENGTH = 30;
  *     like: boolean;
  *     bookmark: boolean;
  *     mainActivated: boolean;
- *   }[],
- *   pageCallback: () => void
+ *   }[];
+ *   infScrollTargetRef;
  * }} props
  */
 export default function FeedSearchResult({
   searchResult,
-  pageCallback
+  infScrollTargetRef
 }) {
   console.log(searchResult);
   return (
-    <div className="list-container">
+    <div className="scroll list-container">
       {
-        searchResult.map((data, idx) => (
+        searchResult && searchResult.map((data, idx) => (
           <FeedSearchResultItem
               key={`feed-search-${idx}`}
               feedId={data.feedId}
@@ -45,6 +45,7 @@ export default function FeedSearchResult({
               text={data.feedText}
               buildingName={data.buildingName}
               thumbnailUrl={data.feedAttachementURL}
+              infScrollTargetRef={idx + 1 === searchResult.length ? infScrollTargetRef : null}
           />
         ))
       }
@@ -66,7 +67,7 @@ export default function FeedSearchResult({
 * }} prop
 */
 function FeedSearchResultItem({
-  feedId, writer, writtenTime, title, text, buildingName, thumbnailUrl
+  feedId, writer, writtenTime, title, text, buildingName, thumbnailUrl, infScrollTargetRef
 }) {
   const navigate = useNavigate();
   const periodInSeconds = (new Date() - writtenTime) / 1000;
@@ -86,6 +87,7 @@ function FeedSearchResultItem({
     <div
         className="item-container"
         onClick={() => navigate(`/feed/detail?feedId=${feedId}`)}
+        ref={infScrollTargetRef}
     >
       <div className="feed-info">
         <div className="feed-metadata">

--- a/src/pages/search/component/FeedSearchResult.jsx
+++ b/src/pages/search/component/FeedSearchResult.jsx
@@ -1,21 +1,4 @@
-import { useEffect, useState } from "react";
 import "../../../assets/css/module/search/component/FeedSearchResult.css";
-
-const SAMPLE_DATA = [];
-
-for (let i = 1; i <= 5; i++) {
-  SAMPLE_DATA.push({
-    writer: {
-      nickname: `nickname-${i}`,
-      profilePhotoUrl: `url-${i}`
-    },
-    writtenTime: new Date() - i * i * i,
-    title: `title-${i}`,
-    text: `text-${i}`,
-    buildingName: `buildingName-${i}`,
-    thumnailUrl: `thumbnailUrl-${i}`
-  });
-}
 
 const MINUTE = 60;
 const HOUR = MINUTE * 60;

--- a/src/pages/search/component/FeedSearchResult.jsx
+++ b/src/pages/search/component/FeedSearchResult.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import "../../../assets/css/module/search/component/FeedSearchResult.css";
 
 const MINUTE = 60;
@@ -67,6 +68,7 @@ export default function FeedSearchResult({
 function FeedSearchResultItem({
   feedId, writer, writtenTime, title, text, buildingName, thumbnailUrl
 }) {
+  const navigate = useNavigate();
   const periodInSeconds = (new Date() - writtenTime) / 1000;
   let timeDisplay;
 
@@ -81,7 +83,10 @@ function FeedSearchResultItem({
   }
 
   return (
-    <div className="item-container">
+    <div
+        className="item-container"
+        onClick={() => navigate(`/feed/detail?feedId=${feedId}`)}
+    >
       <div className="feed-info">
         <div className="feed-metadata">
           <div className="sub-info">

--- a/src/pages/search/component/MemberSearchResult.jsx
+++ b/src/pages/search/component/MemberSearchResult.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import "../../../assets/css/module/search/component/MemberSearchResult.css";
+import { useNavigate } from "react-router-dom";
+import useEncryptId from "../../member/component/common/useEncryptId";
 
 const SAMPLE_DATA = [];
 
@@ -75,8 +77,13 @@ function MemberSearchResultItem({
   follower,
   following
 }) {
+  const navigate = useNavigate();
+  const {encryptedData, ivData} =useEncryptId(memberId);
   return (
-    <div className="member-item-container">
+    <div
+        className="member-item-container"
+        onClick={() => navigate(`/member/getMemberProfile/${encryptedData}/${ivData}`)}
+    >
       <img src={profilePhotoUrl} alt="Profile" />
       <div className="member-name-container">
         <div className="nickname">{nickname}</div>

--- a/src/pages/search/component/MemberSearchResult.jsx
+++ b/src/pages/search/component/MemberSearchResult.jsx
@@ -31,18 +31,18 @@ for (let i = 0; i < 5; i++) {
  *       following: boolean;
  *     }[]
  *   },
- *   pageCallback: () => void;
+ *   infScrollTargetRef;
  * }} props
  */
 export default function MemberSearchResult({
   searchResult,
-  pageCallback
+  infScrollTargetRef
 }) {
 
   return (
-    <div className="list-container">
+    <div className="scroll list-container">
       {
-        searchResult?.info?.content && searchResult.info.content.map((data, idx) => (
+        searchResult && searchResult.map((data, idx) => (
           <MemberSearchResultItem
             key={`member-data-${idx}`}
             profilePhotoUrl={data.profilePhotoUrl}
@@ -50,6 +50,7 @@ export default function MemberSearchResult({
             nickname={data.nickname}
             following={data.following}
             followed={data.followed}
+            infScrollTargetRef={idx + 1 === searchResult.length ? infScrollTargetRef : null}
           />
         ))
       }
@@ -75,12 +76,14 @@ function MemberSearchResultItem({
   profilePhotoUrl,
   profileIntro,
   follower,
-  following
+  following,
+  infScrollTargetRef
 }) {
   const navigate = useNavigate();
   const {encryptedData, ivData} =useEncryptId(memberId);
   return (
     <div
+        ref={infScrollTargetRef}
         className="member-item-container"
         onClick={() => navigate(`/member/getMemberProfile/${encryptedData}/${ivData}`)}
     >


### PR DESCRIPTION
## 요약
Search 페이지의 검색 결과를 누르면 다른 컴포넌트로 이동합니다.
무한 스크롤도 구현했습니다.

## 변경 사항 설명
- 피드 검색 결과 누르면 해당 피드 상세 보기로 이동
- 채팅방 검색 결과 누르면 해당 채팅방으로 이동
- 건물 검색 결과 누르면 해당 건물 상세 보기로 이동
- 회원 검색 결과 누르면 해당 회원 프로필로 이동
- 무한 스크롤 구현
- 도저히 안 되겠어서 "피드" 검색 결과 조회하다가 "채팅방" 검색 탭으로 이동하면 피드 검색 결과는 초기화되는 걸로 했습니다. 구현하기 너무 빡세더라구요. 피드, 채팅방, 건물, 회원 모두 해당됩니다.

![init](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/f6303d8c-bd4d-41f1-9996-652e22ebf4dd)
ㄴ 이런 겁니다

### 피드로 이동

![inf_scrolll](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/26e11f2a-b3a8-4fb6-8669-184cbffce54b)

일단 피드만 예시로 보여드렸는데 다른 것도 됩니다.

### 무한 스크롤

![inf_scroll4](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/485e4177-749a-417a-85d0-c466d6ddcc40)

## 관련 이슈 및 참고 자료
(작성한 이슈를 작성하고 추가로 이해를 위한 참고자료가 있다면 공유 부탁드립니다)
