### PR TITLE
refactor : 공지사항 작성, 건물 등록 신청

### DIFF
--- a/src/pages/CustomerSupport/AddNotice.jsx
+++ b/src/pages/CustomerSupport/AddNotice.jsx
@@ -1,20 +1,18 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import '../CustomerSupport/css/text-editor.css';
 import axiosInstance from '../../lib/axiosInstance';
+import { useSelector } from 'react-redux';
 
 import CustomerSupportHeader from './components/CustomerSupportHeader';
 import Footer from '../../components/common/Footer';
 
-
-
-
 const AddNotice = () => {
+  const member = useSelector((state) => state.auth.member);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const quillRef = useRef(null);
-
 
   const handleTitleChange = (e) => {
     setTitle(e.target.value);
@@ -24,49 +22,71 @@ const AddNotice = () => {
     setContent(value);
   };
 
-  const handleAddNotice = async () => {
+  const handleImageUpload = async (file) => {
+    const formData = new FormData();
+    formData.append('attachment', file);
+
     try {
-      const response = await axiosInstance.post('/customersupport/addNotice', {
-        title: title,
-        feedText: content,
+      const response = await axiosInstance.post('/customersupport/uploadImage', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      console.log(JSON.stringify(response.data));
+
+      return response.data; // 서버에서 반환한 이미지 URL
+    } catch (error) {
+      console.error('Error uploading attachment:', error);
+      return null;
+    }
+  };
+
+  const insertImage = async () => {
+
+    console.log("insertImage");
+
+    const input = document.createElement('input');
+    input.setAttribute('type', 'file');
+    input.setAttribute('accept', 'image/*');
+    input.click();
+
+    input.onchange = async () => {
+      const file = input.files[0];
+
+      if (file) {
+        const imageUrl = await handleImageUpload(file);
+        console.log(imageUrl);
+
+        if (imageUrl) {
+          const quill = quillRef.current.getEditor();
+          const range = quill.getSelection();
+          quill.insertEmbed(range.index, 'image', imageUrl);
+          console.log(`Inserted image URL: ${imageUrl}`);
+        }
+      }
+    };
+  };
+
+  const handleAddNotice = async () => {
+    const editorContent = quillRef.current.getEditor().root.innerHTML;
+    const formData = new FormData();
+    formData.append('writerId', member.memberId);
+  
+    formData.append('title', title);
+    formData.append('feedText', editorContent);
+
+    try {
+      const response = await axiosInstance.post('/customersupport/addNotice', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
       });
       console.log('Notice added:', response.data);
     } catch (error) {
       console.error('Error adding notice:', error);
     }
   };
-
-  const handleImageUpload = (file) => {
-    const formData = new FormData();
-    formData.append('image', file);
-
-    axiosInstance.post('/customersupport/addNotice', formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-      .then(response => {
-        const quill = quillRef.current.getEditor();
-        const range = quill.getSelection();
-        quill.insertEmbed(range.index, 'image', response.data.imageUrl);
-      })
-      .catch(error => {
-        console.error('Error uploading image:', error);
-      });
-  };
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      // 필요한 로직 추가
-    });
-    const editor = quillRef.current.getEditor().root;
-    observer.observe(editor, { childList: true, subtree: true });
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
 
   const modules = useMemo(() => {
     return {
@@ -77,25 +97,11 @@ const AddNotice = () => {
           ['bold', 'italic', 'underline', 'strike', 'blockquote'],
         ],
         handlers: {
-          image: () => {
-            const input = document.createElement('input');
-            input.setAttribute('type', 'file');
-            input.setAttribute('accept', 'image/*');
-            input.click();
-  
-            input.onchange = () => {
-              const file = input.files[0];
-              if (file) {
-                handleImageUpload(file);
-              }
-            };
-          },
+          image: insertImage,
         },
       },
     };
   }, []);
-
-
 
   const formats = [
     'header', 'font', 'size',
@@ -123,10 +129,10 @@ const AddNotice = () => {
           onChange={handleTextChange} 
           modules={modules} 
           formats={formats} 
-          style={{ height: '350px', marginBottom: '50px' }}
+          style={{ height: '300px', marginBottom: '50px' }}
         />
       </div>
-      <button onClick={handleAddNotice} style={{ padding: '10px 20px', fontSize: '16px', marginBottom: '100px',  backgroundColor: '#030722'}}>
+      <button onClick={handleAddNotice} style={{ padding: '10px 20px', fontSize: '16px', marginBottom: '100px', backgroundColor: '#030722', color: '#FFFFFF' }}>
         등록
       </button>
       <Footer/>

--- a/src/pages/CustomerSupport/GetNotice.jsx
+++ b/src/pages/CustomerSupport/GetNotice.jsx
@@ -93,7 +93,7 @@ const GetNotice = () => {
           <Row>
             <Col md="12">
               <Card>
-                <CardHeader>공지제목: {notice.title}</CardHeader>
+                <CardHeader>{notice.title}</CardHeader>
                 <CardBody>
                   <Table responsive>
                     <thead className="text-primary">

--- a/src/pages/CustomerSupport/GetNotice.jsx
+++ b/src/pages/CustomerSupport/GetNotice.jsx
@@ -115,9 +115,7 @@ const GetNotice = () => {
               <Card>
                 <CardHeader>내용</CardHeader>
                 <CardBody>
-                  <div>
-                    {notice.feedText}
-                  </div>
+                  <div dangerouslySetInnerHTML={{ __html: notice.feedText }} />
                 </CardBody>
               </Card>
 

--- a/src/pages/building/components/ApplicantSample.jsx
+++ b/src/pages/building/components/ApplicantSample.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import WantBuildingProfile from '../components/WantBuildingProfile'
+
+const ApplicantSample = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const applicationData = {
+    buildingName: '삼오빌딩',
+    roadAddr: '123 Sample Street, Sample City, Sample Country',
+    longitude: 127.03642,
+    latitude: 37.50124,
+  };
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div style={styles.page}>
+      <h1>Sample Page</h1>
+      <button style={styles.openModalButton} onClick={openModal}>
+        Open Modal
+      </button>
+      <WantBuildingProfile
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        applicationData={applicationData}
+      />
+    </div>
+  );
+};
+
+const styles = {
+  page: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    backgroundColor: '#f5f5f5',
+  },
+  openModalButton: {
+    padding: '10px 20px',
+    fontSize: '16px',
+    cursor: 'pointer',
+  },
+};
+
+export default ApplicantSample;

--- a/src/pages/building/components/BuildingInfo.jsx
+++ b/src/pages/building/components/BuildingInfo.jsx
@@ -193,7 +193,7 @@ const BuildingInfo = () => {
                           <Button block color="primary" onClick={getWikipage}>
                             건물 위키 보기
                           </Button>
-                        </Col>
+                    </Col>
                   </Row>
                 </div>
               </CardFooter>

--- a/src/pages/building/components/TabNavigation.jsx
+++ b/src/pages/building/components/TabNavigation.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import FeedList from '../../feed/FeedListPage'
+import FeedList from '../../feed/FeedListPage';
+import FeedBuildingListPage from '../../feed/FeedBuildingListPage';
 import ChatroomList from './ChatroomList';
 import { useNavigate } from 'react-router-dom';
 
@@ -32,7 +33,7 @@ const TabNavigation = () => {
         {activeTab === 'feed' ? ( <button onClick={handleCreationLink} >FEED+</button> ) : ( <button onClick={handleCreationLink}>CHAT+</button> )}
       </div>
       <div className="tab-content">
-        {activeTab === 'feed' ? <FeedList /> : <ChatroomList />}
+        {activeTab === 'feed' ? <FeedBuildingListPage /> : <ChatroomList />}
       </div>
       <div className="create-button">
         

--- a/src/pages/feed/FeedBuildingListPage.jsx
+++ b/src/pages/feed/FeedBuildingListPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import FeedItem from './component/FeedList/FeedItem';
 import FeedNotFound from './component/FeedNotFound';
@@ -23,7 +23,7 @@ const FeedBuildingListPage = () => {
     const memberIdFromStore = useSelector((state) => state.auth.member.memberId);
     const memberIdFromURL = searchParams.get('memberId');
     const memberId = memberIdFromStore || memberIdFromURL;
-    const buildingId = searchParams.get('buildingId');
+    const { buildingId } = useParams();
     const initialPage = searchParams.get('page') || 1;
 
     const [feeds, setFeeds] = useState([]);

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -68,6 +68,7 @@ import FeedChartPage from '../pages/feed/FeedChartPage';
 import FeedBuildingListPage from '../pages/feed/FeedBuildingListPage';
 import FeedListHomePage from '../pages/feed/FeedListHomePage';
 import GetMemberProfile from "../pages/member/GetMemberProfile";
+import ApplicantSample from "../pages/building/components/ApplicantSample";
 const AppRoutes = () => {
   const location = useLocation();
   const navigationType = useNavigationType();
@@ -233,6 +234,7 @@ const AppRoutes = () => {
         <Route path="/map" element={<BMap />} />
         <Route path="/search" element={<Search />} />
         <Route path="/getBuildingProfile/:buildingId" element={<GetBuilding />} />
+        <Route path="/applicantSample" element={<ApplicantSample/>}/>
          <Route path="/customerSupport">
             <Route path="" element={<GetCustomerSupport />} />
             <Route path="getChatbot" element={<GetChatbot />} />


### PR DESCRIPTION
## 요약
공지사항 작성, 건물 등록 신청 부분을 리팩토링했습니다.

## 변경 사항 설명
공지사항 작성에서 텍스트 사이사이에 이미지와 동영상을 추가할 수 있게 하였습니다.
건물 등록 신청을 모달로 바꾸고, 신청 및 신청 취소를 구현했습니다.
경도님께서 건물 신청 모달을 연결해주시기 전까지 /applicantSample 페이지로 테스트 할 수 있습니다. 지금은 2명이 신청하면 빌딩 페이지로 이동하도록 합니다.

## 관련 이슈 및 참고 자료

![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/f4ee9a42-972c-4787-8e60-22249af4043b)

![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/88bbea68-8358-471e-8a9a-3971cf8f3783)

![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/bdc55709-f70f-476b-8170-64839c9cd6dd)
