### PR TITLE
design: 환경설정 페이지 디자인 리팩토링

### DIFF
--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -6,6 +6,8 @@ import { is2xxStatus } from "../../util/statusCodeUtil";
 import BasicNavbar from "../../components/common/BasicNavbar";
 import "./css/MemberSetting.css";
 import OpInfoModal from "./component/OpInfoModal";
+import { RiArrowGoBackFill } from "react-icons/ri";
+import { useNavigate } from "react-router-dom";
 
 const PUBLIC_RANGES = [
   {
@@ -38,6 +40,8 @@ export default function MemberSetting() {
     useState("PUBLIC");
   const [opInfoMode, setOpInfoMode] = useState("termsAndPolicy");
   const [opInfoModalVisible, setOpInfoModalVisible] = useState(false);
+
+  const navigate = useNavigate();
 
   const memberId = SAMPLE_MEMBER_ID;
 
@@ -95,8 +99,19 @@ export default function MemberSetting() {
   return (
     <div>
       <BasicNavbar />
+      
       <main className="container member-setting-container">
-        <h1>환경설정</h1>
+        <div class="title-container">
+          <h1>환경설정</h1>
+          <RiArrowGoBackFill
+              style={{
+                  width: "25px", height: "25px"
+              }}
+              onClick={() => {
+                navigate(-1);
+              }}
+          />
+        </div>
         <div className="setting-content-wrapper">
           {
             COMPONENT_INFOS.map((data, idx) => (

--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -126,28 +126,49 @@ export default function MemberSetting() {
             ))
           }
         </div>
-        <button className="btn--apply-setting" type="button" onClick={() => {
-          axios_api.post(`${MAIN_API_URL}/setting/updateSetting/${memberId}`, {
-            memberProfilePublicRange,
-            allFeedPublicRange,
-            buildingSubscriptionPublicRange,
-            receivingAllNotification
-          }).then((response) => {
-            if (is2xxStatus(response.status)) {
-              alert("환경설정이 적용되었습니다");
-            }
-          }).catch((err) => {
-            console.error(err);
-          })
-        }}>변경사항 저장</button>
-        <button className="btn--opinfo" type="button" onClick={() => {
-          setOpInfoMode("termsAndPolicy");
-          setOpInfoModalVisible(true);
-        }}>약관 및 정책</button>
-        <button className="btn--opinfo" type="button" onClick={() => {
-          setOpInfoMode("termsOfUse");
-          setOpInfoModalVisible(true);
-        }}>이용규정</button>
+        <button
+            className="btn--apply-setting"
+            type="button"
+            onClick={() => {
+              axios_api.post(`${MAIN_API_URL}/setting/updateSetting/${memberId}`, {
+                memberProfilePublicRange,
+                allFeedPublicRange,
+                buildingSubscriptionPublicRange,
+                receivingAllNotification
+              }).then((response) => {
+                if (is2xxStatus(response.status)) {
+                  alert("환경설정이 적용되었습니다");
+                }
+              }).catch((err) => {
+                console.error(err);
+              })
+            }}
+            style={{ backgroundColor: "#030722" }}
+        >변경사항 저장</button>
+        <button
+            className="btn--opinfo"
+            type="button"
+            onClick={() => {
+              setOpInfoMode("termsAndPolicy");
+              setOpInfoModalVisible(true);
+            }}
+            style={{
+              color: "#030722",
+              backgroundColor: "#FFFFFD"
+            }}
+        >약관 및 정책</button>
+        <button
+            className="btn--opinfo"
+            type="button"
+            onClick={() => {
+              setOpInfoMode("termsOfUse");
+              setOpInfoModalVisible(true);
+            }}
+            style={{
+              color: "#030722",
+              backgroundColor: "#FFFFFD"
+            }}
+        >이용규정</button>
         <OpInfoModal
             visible={opInfoModalVisible}
             setVisible={setOpInfoModalVisible}

--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -95,7 +95,7 @@ export default function MemberSetting() {
   return (
     <div>
       <BasicNavbar />
-      <main className="container">
+      <main className="container member-setting-container">
         <h1>환경설정</h1>
         <div className="setting-content-wrapper">
           {

--- a/src/pages/setting/css/MemberSetting.css
+++ b/src/pages/setting/css/MemberSetting.css
@@ -1,19 +1,35 @@
-main {
+.member-setting-container {
   width: 80%;
   display: flex;
   flex-direction: column;
 }
 
-main h1 {
+.member-setting-container h1 {
   margin-bottom: 48px;
 }
 
 .pg-dropdown {
   width: 128px;
+  border-color: #9BAAF8;
 }
 
 .pg-dropdown button {
   width: 100%;
+}
+
+.member-setting-container button {
+  background-color: #9BAAF8;
+  border-color: #9BAAF8;
+}
+
+.member-setting-container button:hover {
+  background-color: #D9D9D9;
+  border-color: #D9D9D9;
+}
+
+.member-setting-container button:active {
+  background-color: #D9D9D9;
+  border-color: #D9D9D9;
 }
 
 .setting-content-wrapper {
@@ -26,6 +42,7 @@ main h1 {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  margin-left: 16px;
 }
 
 .setting-content * {
@@ -33,11 +50,12 @@ main h1 {
 }
 
 .btn--apply-setting {
-  margin-top: 36px;
+  margin-top: 48px;
   width: fit-content;
   padding: 12px 36px;
   border-radius: 5px;
-  margin-left: 18px;
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: 18px;
   font-size: 24px;
 }

--- a/src/pages/setting/css/MemberSetting.css
+++ b/src/pages/setting/css/MemberSetting.css
@@ -4,8 +4,15 @@
   flex-direction: column;
 }
 
-.member-setting-container h1 {
+.title-container {
   margin-bottom: 48px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title-container h1 {
+  margin-bottom: 0px;
 }
 
 .pg-dropdown {


### PR DESCRIPTION
## 요약
환경설정 페이지의 디자인을 수정하고 뒤로가기 버튼을 추가했습니다.

## 변경 사항 설명
- 뒤로 가기 버튼 추가 (이거는 나중에 통합할 때 뺄 수도 있음)
- 버튼 색상 변경
- 레이아웃 변경 (마진, 패딩 사이즈 다소 수정한 거라 눈에 잘 안 띔)

![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/0b16e81f-a841-40f1-8c23-faf2c4f53a4a)


## 관련 이슈 및 참고 자료
Issue: #123
