### PR TITLE
fix: 장소 검색 시 에러 발생 픽스

### DIFF
--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -244,7 +244,11 @@ function searchPlaceList(searchKeyword, callback, queryParams, setQueryParams) {
  */
 function onSearchPlace(places) {
   console.log(places);
-  clearMarkers(placeSearchMarkers);
+  if (placeSearchMarkers) {
+    for (let marker of placeSearchMarkers) {
+      marker.setMap(null);
+    }
+  }
   const placeSearchMarkersCache = [];
   places.forEach((place) => {
     const contentHtml = getPlaceSearchMarkerHtml(place.roadAddress, place.placeName);


### PR DESCRIPTION
## 요약
기존에 사용하던 데이터 구조가 바뀐 탓에 에러가 발생했다.

## 변경 사항 설명
- onSearchPlace 함수 내에서 clearMarkers 함수를 사용하지 않음

## 관련 이슈 및 참고 자료
Issue: #141
