### PR TITLE
feat: 검색 화면 default 탭 설정

### DIFF
--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -21,7 +21,7 @@ export default function Search() {
   
   const [searchKeyword, setSearchKeyword] = useState(queryParams.has(PARAM_KEY_SEARCH_KEYWORD) ? queryParams.get(PARAM_KEY_SEARCH_KEYWORD) : "");
   const [currentSearchMode, setCurrentSearchMode] =
-      useState(queryParams.has(PARAM_KEY_SEARCH_MODE) ? parseInt(queryParams.get(PARAM_KEY_SEARCH_MODE)) : modes.INTEGRATION);
+      useState(queryParams.has(PARAM_KEY_SEARCH_MODE) ? parseInt(queryParams.get(PARAM_KEY_SEARCH_MODE)) : modes.FEED);
   const [searchResult, setSearchResult] = useState();
   const [page, setPage] = useState(1);
 


### PR DESCRIPTION
## 요약
검색 화면의 default 탭을 피드로 설정한다.

## 변경 사항 설명
검색 화면에 들어가면 기본적으로 피드 검색이 된다.

## 관련 이슈 및 참고 자료
Issue: #160
