### PR TITLE
fix: 현재 로그인한 회원의 환경설정 정보 제공

### DIFF
--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -9,7 +9,7 @@ import OpInfoModal from "./component/OpInfoModal";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { useNavigate } from "react-router-dom";
 import { setFooterEnbaled } from "../../redux/slices/footerEnabledSlice";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 const PUBLIC_RANGES = [
   {
@@ -30,8 +30,6 @@ const PUBLIC_RANGES = [
   }
 ]
 
-const SAMPLE_MEMBER_ID = "member_2";
-
 export default function MemberSetting() {
   const [memberProfilePublicRange, setMemberProfilePublicRange] =
     useState("PUBLIC");
@@ -45,7 +43,7 @@ export default function MemberSetting() {
 
   const navigate = useNavigate();
 
-  const memberId = SAMPLE_MEMBER_ID;
+  const memberId = useSelector((state) => state.auth.member.memberId);
 
   const dispatch = useDispatch();
 


### PR DESCRIPTION
## 요약
이전에는 개발을 위한 샘플용 member_2의 환경설정 정보를 제공했지만 이제는 현재 로그인한 회원의 환경설정 정보를 보여주고 수정할 수 있다.

## 변경 사항 설명
- SAMPLE_MEMBER 삭제
- 현재 로그인한 회원의 환경설정 정보 제공

## 관련 이슈 및 참고 자료
Issue: #162
