### PR TITLE
feat: 건물 클릭 시 건물 프로필로 이동

### DIFF
--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -65,7 +65,6 @@ export default function BMap() {
 
   const loginMember = useSelector((state) => state.auth.member);
 
-  // TODO: Replace sample with real
   const member = ownerIdOfMapInfo ? ownerIdOfMapInfo : loginMember.memberId;
 
   /**
@@ -87,7 +86,7 @@ export default function BMap() {
     naver.maps.Event.addListener(map, "click", (e) => {
       const latitude = e.latlng.y;
       const longitude = e.latlng.x;
-      fetchBuildingInfo(latitude, longitude, setWantBuildingProfileModal);
+      fetchBuildingInfo(latitude, longitude, setWantBuildingProfileModal, navigate);
     });
 
     naver.maps.Event.addListener(map, "dragend", (e) => {
@@ -278,15 +277,15 @@ function getCurrentPosition(callback, errorCallback) {
  * @param {number} latitude 
  * @param {number} longitude 
  */
-function fetchBuildingInfo(latitude, longitude, setWantBuildingProfileModal) {
+function fetchBuildingInfo(latitude, longitude, setWantBuildingProfileModal, navigate) {
   axios_api.get(`${MAIN_API_URL}/buildingProfile/getBuildingProfile`, {
     params: {
       latitude,
       longitude
     }
   }).then((response) => {
-    // TODO: Do somthing later
     console.log(response);
+    navigate(`/getBuildingProfile/${response.data.buildingId}`);
   }).catch((err) => {
     if (is4xxStatus(err.response.status)) {
       const data = err.response.data;


### PR DESCRIPTION
## 요약
지도를 클릭하면 그곳에 있는 건물이 이미 등록된 건물이라면 건물 프로필로
이동함

## 변경 사항 설명

https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/a51e3501-d849-4bf8-8611-cebd8eb1d11c

시계탑 빌딩에는 마커가 달려 있지 않지만 현재 우리 데이터베이스에 제대로 저장된 등록된 건물이다 (마커가 안 나타나는 이유는 건물 프로필 등록할 때 위도, 경도가 서로 뒤바껴서 저장됐기 때문이며 이 문제는 수정될 것이다). 지도에서 시계탑 빌딩이 있는 부분을 클릭하면 해당 건물 프로필로 이동한다. 만약 등록되지 않은 건물이었다면 건물 등록 페이지로 이동할 것이다.

## 관련 이슈 및 참고 자료
Issue: #164