### PR TITLE
feat : 회원 프로필 내 피드 목록 보기 관련 버그 정리

### DIFF
--- a/src/pages/feed/FeedDetailPage.jsx
+++ b/src/pages/feed/FeedDetailPage.jsx
@@ -53,7 +53,7 @@ const FeedDetailPage = () => {
     if(!feed) {
         return (
             <div>
-                <BasicNavbar />
+                {/* <BasicNavbar /> */}
                 <FeedNotFound/>
             </div>
         );
@@ -61,7 +61,7 @@ const FeedDetailPage = () => {
 
     return (
         <div>
-            <BasicNavbar />
+            {/* <BasicNavbar /> */}
             <FeedDetail data={feed} memberId = {memberId} />
             <div>
                 <Footer />

--- a/src/pages/feed/FeedFormPage.jsx
+++ b/src/pages/feed/FeedFormPage.jsx
@@ -51,7 +51,7 @@ const FeedFormPage = () => {
 
     return (
         <div>
-            <BasicNavbar />
+            {/* <BasicNavbar /> */}
             {/* 피드를 새로 추가할 때만 생성 */}
             {feedId ? '' : (
                 <div className="container">

--- a/src/pages/feed/FeedMegaphoneFormPage.jsx
+++ b/src/pages/feed/FeedMegaphoneFormPage.jsx
@@ -49,7 +49,7 @@ const FeedFormPage = () => {
 
     return (
         <div>
-            <BasicNavbar />
+            {/* <BasicNavbar /> */}
             <div className="container">
                 <Button variant="primary" onClick={() => setShowModal(true)}>
                     피드 종류

--- a/src/pages/feed/FeedPages.jsx
+++ b/src/pages/feed/FeedPages.jsx
@@ -16,10 +16,10 @@ const FeedPages = () => {
         <nav>
           <ul>
             <li>
-              <Link to="list?memberId=member_1&page=1">Feed List</Link>
+              <Link to="list?memberId=member_1&loginMemberId=member_1&page=1">Feed List</Link>
             </li>
             <li>
-              <Link to="list/building/10001?memberId=member_1&page=1">Feed Building List</Link>
+              <Link to="list/building/10001?memberId=member_2&page=1">Feed Building List</Link>
             </li>
             <li>
               <Link to="detail?feedId=10001&memberId=member_1">Feed Detail</Link>

--- a/src/pages/feed/FeedVoteFormPage.jsx
+++ b/src/pages/feed/FeedVoteFormPage.jsx
@@ -49,7 +49,7 @@ const FeedFormPage = () => {
 
     return (
         <div>
-            <BasicNavbar />
+            {/* <BasicNavbar /> */}
             <div className="container">
                 <Button variant="primary" onClick={() => setShowModal(true)}>
                     피드 종류

--- a/src/pages/feed/component/FeedForm/FeedForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedForm.jsx
@@ -101,7 +101,7 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                 updateTagList: feedData.updateTagList,
                 feedCategory: feedData.category,
                 publicRange: feedData.publicRange,
-                eventDate: eventDate.toISOString()
+                eventDate: eventDate
             };
 
             console.log(addFeedData);

--- a/src/pages/feed/component/FeedList/FeedDropdown.jsx
+++ b/src/pages/feed/component/FeedList/FeedDropdown.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Dropdown, DropdownButton } from 'react-bootstrap';
+import { ButtonGroup, Button } from 'react-bootstrap';
 
-const FeedDropdown = ({onSelect}) => {
+const FeedDropdown = ({ onSelect }) => {
 
-    // Dropdown을 클릭할 때마다 다른 목록으로 이동
+    // 각 버튼을 클릭할 때 관련 URL을 설정
     const handleSelect = (option) => {
         let temp = '';
         switch (option) {
@@ -28,18 +28,12 @@ const FeedDropdown = ({onSelect}) => {
 
     return (
         <div className="row justify-content-center">
-            <DropdownButton
-                id="dropdown-basic-button"
-                title="피드 목록"
-                onSelect={handleSelect}
-                size="sm" 
-                variant="primary" 
-            >
-                <Dropdown.Item eventKey="member">내 피드</Dropdown.Item>
-                <Dropdown.Item eventKey="subscriptionBuilding">건물 구독별 피드</Dropdown.Item>
-                <Dropdown.Item eventKey="like">좋아요를 누른 피드</Dropdown.Item>
-                <Dropdown.Item eventKey="bookmark">북마크한 피드</Dropdown.Item>
-            </DropdownButton>
+            <ButtonGroup>
+                <Button variant="primary" onClick={() => handleSelect('member')}>내 피드</Button>
+                <Button variant="primary" onClick={() => handleSelect('subscriptionBuilding')}>구독한 건물 피드</Button>
+                <Button variant="primary" onClick={() => handleSelect('like')}>좋아요를 한 피드</Button>
+                <Button variant="primary" onClick={() => handleSelect('bookmark')}>북마크한 피드</Button>
+            </ButtonGroup>
         </div>
     );
 };


### PR DESCRIPTION
## 요약
회원 프로필에 있는 피드 목록 보기 버그를 완화했습니다.

## 변경 사항 설명
### 1. 전체적인 로직 수정
다른 회원의 프로필을 볼 때 각종 버그가 발생한 것을 해결했습니다.  
로그인한 회원과 프로필 목록을 보여줄 회원을 분리하여 새롭게 로직을 구성했습니다.
자세한 내용은 API의 PR을 참고하면 좋을 거 같습니다.
https://github.com/kuberMAPtes/noon-main-api-server/pull/212

### 2. 일부 UI 변경
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/600a92ad-f7ae-457a-a305-0fde836fc659)
Dropdown 버튼에서 버튼 여러개를 통해 한 번에 전환하는게 더 좋다고 생각해서 일부 수정했습니다.

## 관련 이슈 및 참고 자료
없음
