### PR TITLE
feat: Loading Spinner 추가

### DIFF
--- a/src/assets/css/module/map/BMap.module.css
+++ b/src/assets/css/module/map/BMap.module.css
@@ -36,3 +36,17 @@
   top: 8%;
   right: 3%
 }
+
+.loadingSpinnerContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 64px;
+  position: absolute;
+  top: 2%;
+  left: 12px;
+}
+
+.loadingSpinner {
+  z-index: 99;
+}

--- a/src/pages/building/wiki/GetBuildingWiki.jsx
+++ b/src/pages/building/wiki/GetBuildingWiki.jsx
@@ -32,8 +32,8 @@ export default function GetBuildingWiki() {
         setContent(fetched);
       }).catch((err) => {
         console.log(err);
-        setBuildingName("Page Error");
-        setContent($(`<p className="mw-parser-output">404 Not Found</p>`));
+        setBuildingName("Wiki가 존재하지 않습니다.");
+        setContent($(`<p className="mw-parser-output">아마도 위키 페이지 생성 중일 것입니다.</p>`));
       })
     }
 

--- a/src/pages/building/wiki/GetBuildingWiki.jsx
+++ b/src/pages/building/wiki/GetBuildingWiki.jsx
@@ -6,6 +6,7 @@ import wikiStyles from "../../../assets/css/module/building/wiki/GetBuildingWiki
 import "../../../assets/css/module/building/wiki/GetBuildingWiki.css"
 import { FaPencil } from "react-icons/fa6";
 import { RiArrowGoBackFill } from "react-icons/ri";
+import { Spinner } from "reactstrap";
 
 export const BUILDING_WIKI_BASE_PATH = "/buildingWiki";
 
@@ -14,6 +15,7 @@ export default function GetBuildingWiki() {
 
   const [buildingName, setBuildingName] = useState("");
   const [content, setContent] = useState();
+  const [loading, setLoading] = useState(true);
 
   const navigate = useNavigate();
   
@@ -47,6 +49,7 @@ export default function GetBuildingWiki() {
       $(document).find(".mw-parser-output").remove();
       content.find(".mw-editsection").remove();
       $(document).find("#wiki-container").append(content);
+      setLoading(false);
     }
   }, [content]);
 
@@ -64,6 +67,17 @@ export default function GetBuildingWiki() {
       </div>
       <h1>{buildingName}</h1>
       <hr className={wikiStyles.contentSeparator} />
+      {
+        loading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <Spinner style={{ width: '3rem', height: '3rem' }} color="primary" />
+          </div>
+        ) : (
+          <>
+            
+          </>
+        )
+      }
     </div>
   );
 }

--- a/src/pages/map/contant/markerHtml.js
+++ b/src/pages/map/contant/markerHtml.js
@@ -56,8 +56,8 @@ export function getPlaceSearchMarkerHtml(
     markerImage = "./image/marker.png"
 ) {
   const content = `
-    <div>${placeName}</div>
-    <div>${roadAddress}</div>
+    <div style="width: fit-content">${placeName}</div>
+    <div style="width: fit-content">${roadAddress}</div>
   `;
 
   return getCommonHtml(content, markerImage)
@@ -70,7 +70,7 @@ export function getPlaceSearchMarkerHtml(
 function getCommonHtml(content, markerImage) {
   return `
     <div style="display: flex; flex-direction: column; align-items: center; width: fit-content; height: fit-content; margin: 0px; padding: 0px">
-      <div style="text-align: center;">
+      <div style="text-align: center; overflow: hidden; white-space: nowrap; display: flex; flex-direction: column; justify-content: center; align-items: center">
         ${content}
       </div>
       <div style="display: flex; justify-content: center; align-items: center; ">

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -124,6 +124,12 @@ export default function Search() {
         setSearchResult(newSearchResult);
         setLoading(false);
       }, loginMemberId);
+    } else if (searchKeyword === "") {
+      queryParams.delete(PARAM_KEY_SEARCH_KEYWORD);
+      setPage(1);
+      setQueryParams(queryParams);
+      setSearchResult([]);
+      setLoading(false);
     }
   }
 

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -12,6 +12,7 @@ import searchMember from "./axios/searchMember";
 import "../../assets/css/module/search/Search.css";
 import { useSearchParams } from "react-router-dom";
 import { useSelector } from "react-redux";
+import { Spinner } from "reactstrap";
 
 
 const PARAM_KEY_SEARCH_MODE = "search-mode";
@@ -88,6 +89,7 @@ export default function Search() {
       searchFunction(searchKeyword, page, (data) => {
         if (!data || data.length === 0) {
           setHasMore(false);
+          setLoading(false);
           return;
         }
         setHasMore(true);
@@ -142,6 +144,11 @@ export default function Search() {
       <SearchBar typeCallback={(text) => setSearchKeyword(text)} searchCallback={onSearchBtnClick} />
       <SearchModeTab currentSearchMode={currentSearchMode} onModeChange={onModeChange} />
       {component}
+      {loading && (
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+          <Spinner style={{ width: '3rem', height: '3rem' }} color="primary" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -145,6 +145,7 @@ export default function MemberSetting() {
                 className="btn--apply-setting"
                 type="button"
                 onClick={() => {
+                  setLoading(true);
                   axios_api.post(`${MAIN_API_URL}/setting/updateSetting/${memberId}`, {
                     memberProfilePublicRange,
                     allFeedPublicRange,
@@ -154,6 +155,7 @@ export default function MemberSetting() {
                     if (is2xxStatus(response.status)) {
                       alert("환경설정이 적용되었습니다");
                     }
+                    setLoading(false);
                   }).catch((err) => {
                     console.error(err);
                   })

--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -10,6 +10,7 @@ import { RiArrowGoBackFill } from "react-icons/ri";
 import { useNavigate } from "react-router-dom";
 import { setFooterEnbaled } from "../../redux/slices/footerEnabledSlice";
 import { useDispatch, useSelector } from "react-redux";
+import { Spinner } from "reactstrap";
 
 const PUBLIC_RANGES = [
   {
@@ -40,6 +41,7 @@ export default function MemberSetting() {
     useState("PUBLIC");
   const [opInfoMode, setOpInfoMode] = useState("termsAndPolicy");
   const [opInfoModalVisible, setOpInfoModalVisible] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const navigate = useNavigate();
 
@@ -55,6 +57,7 @@ export default function MemberSetting() {
         setting.buildingSubscriptionPublicRange
       );
       setReceivingAllNotification(setting.receivingAllNotificationAllowed);
+      setLoading(false);
     });
     dispatch(setFooterEnbaled(false));
 
@@ -106,82 +109,89 @@ export default function MemberSetting() {
   return (
     <div>
       <BasicNavbar />
-      
-      <main className="container member-setting-container">
-        <div class="title-container">
-          <h1>환경설정</h1>
-          <RiArrowGoBackFill
-              style={{
-                  width: "25px", height: "25px"
-              }}
-              onClick={() => {
-                navigate(-1);
-              }}
-          />
-        </div>
-        <div className="setting-content-wrapper">
-          {
-            COMPONENT_INFOS.map((data, idx) => (
-              <div className="setting-content" key={`button-group-${idx}`}>
-                <h3>{data.header}</h3>
-                <PublicRangeDropdown
-                  currentSelectedId={data.currentSelected}
-                  buttonInfos={data.buttonInfos}
-                  onButtonClick={data.callback}
-                />
-              </div>
-            ))
-          }
-        </div>
-        <button
-            className="btn--apply-setting"
-            type="button"
-            onClick={() => {
-              axios_api.post(`${MAIN_API_URL}/setting/updateSetting/${memberId}`, {
-                memberProfilePublicRange,
-                allFeedPublicRange,
-                buildingSubscriptionPublicRange,
-                receivingAllNotification
-              }).then((response) => {
-                if (is2xxStatus(response.status)) {
-                  alert("환경설정이 적용되었습니다");
-                }
-              }).catch((err) => {
-                console.error(err);
-              })
-            }}
-            style={{ backgroundColor: "#030722" }}
-        >변경사항 저장</button>
-        <button
-            className="btn--opinfo"
-            type="button"
-            onClick={() => {
-              setOpInfoMode("termsAndPolicy");
-              setOpInfoModalVisible(true);
-            }}
-            style={{
-              color: "#030722",
-              backgroundColor: "#FFFFFD"
-            }}
-        >약관 및 정책</button>
-        <button
-            className="btn--opinfo"
-            type="button"
-            onClick={() => {
-              setOpInfoMode("termsOfUse");
-              setOpInfoModalVisible(true);
-            }}
-            style={{
-              color: "#030722",
-              backgroundColor: "#FFFFFD"
-            }}
-        >이용규정</button>
-        <OpInfoModal
-            visible={opInfoModalVisible}
-            setVisible={setOpInfoModalVisible}
-            mode={opInfoMode}
-        />
-      </main>
+      {
+        loading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <Spinner style={{ width: '3rem', height: '3rem' }} color="primary" />
+          </div>
+        ) : (
+          <main className="container member-setting-container">
+            <div class="title-container">
+              <h1>환경설정</h1>
+              <RiArrowGoBackFill
+                  style={{
+                      width: "25px", height: "25px"
+                  }}
+                  onClick={() => {
+                    navigate(-1);
+                  }}
+              />
+            </div>
+            <div className="setting-content-wrapper">
+              {
+                COMPONENT_INFOS.map((data, idx) => (
+                  <div className="setting-content" key={`button-group-${idx}`}>
+                    <h3>{data.header}</h3>
+                    <PublicRangeDropdown
+                      currentSelectedId={data.currentSelected}
+                      buttonInfos={data.buttonInfos}
+                      onButtonClick={data.callback}
+                    />
+                  </div>
+                ))
+              }
+            </div>
+            <button
+                className="btn--apply-setting"
+                type="button"
+                onClick={() => {
+                  axios_api.post(`${MAIN_API_URL}/setting/updateSetting/${memberId}`, {
+                    memberProfilePublicRange,
+                    allFeedPublicRange,
+                    buildingSubscriptionPublicRange,
+                    receivingAllNotification
+                  }).then((response) => {
+                    if (is2xxStatus(response.status)) {
+                      alert("환경설정이 적용되었습니다");
+                    }
+                  }).catch((err) => {
+                    console.error(err);
+                  })
+                }}
+                style={{ backgroundColor: "#030722" }}
+            >변경사항 저장</button>
+            <button
+                className="btn--opinfo"
+                type="button"
+                onClick={() => {
+                  setOpInfoMode("termsAndPolicy");
+                  setOpInfoModalVisible(true);
+                }}
+                style={{
+                  color: "#030722",
+                  backgroundColor: "#FFFFFD"
+                }}
+            >약관 및 정책</button>
+            <button
+                className="btn--opinfo"
+                type="button"
+                onClick={() => {
+                  setOpInfoMode("termsOfUse");
+                  setOpInfoModalVisible(true);
+                }}
+                style={{
+                  color: "#030722",
+                  backgroundColor: "#FFFFFD"
+                }}
+            >이용규정</button>
+            <OpInfoModal
+                visible={opInfoModalVisible}
+                setVisible={setOpInfoModalVisible}
+                mode={opInfoMode}
+            />
+          </main>
+        )
+      }
     </div>
   );
 }


### PR DESCRIPTION
## 요약
검색, 건물위키, 지도, 환경설정에서 데이터를 가져고 오는 동안 Spinner가 돌아가는 로딩 UI 구현

## 변경 사항 설명
- 검색 화면에서 검색 시 Spinner 노출
- 무한스크롤을 통해 검색결과를 더 가지고 올 때 Spinner 노출
- 환경설정 정보 가져올 때 로딩 UI 노출
- 환경설정 변경 반영할 때 로딩 UI 노출
- 지도에서 장소 검색할 때 마커 이름이 여러 줄에 걸쳐서 나오는 거 고침 (이제 한 줄로 나옴)
- 건물 위키 로딩 UI
- 검색창에 아무것도 입력하지 않고 검색 버튼 누르면 검색 결과 초기화

### 검색 화면에서 로딩 UI

https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/709421a5-a4d0-4e71-8a4a-1c140d7aa693

### 지도 화면에서 로딩 UI

https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/f9d303ec-6194-45e8-9f5c-4a3ee8ea1ae6

로딩이 너무 빨라서 다 못 보여줌

## 관련 이슈 및 참고 자료
Issue: #137
