### PR TITLE
fix : 요구사항 변경 및 버그 수정

### DIFF
--- a/src/pages/feed/FeedDetailPage.jsx
+++ b/src/pages/feed/FeedDetailPage.jsx
@@ -6,7 +6,9 @@ import FeedNotFound from './component/FeedNotFound'
 import axios_api from '../../lib/axios_api';
 import Loading from './component/FeedList/FeedLoading';
 import Footer from '../../components/common/Footer';
+import navigator from './util/Navigator'
 import { useSelector } from 'react-redux';
+import { Button } from 'react-bootstrap';
 
 
 /**
@@ -23,6 +25,7 @@ const FeedDetailPage = () => {
     const memberId = memberIdFromStore || memberIdFromURL;
 
     const [feed, setFeed] = useState(null);
+    const [buildingId, setBuildingId] = useState(0);
     const [loading, setLoading] = useState(false);
 
     useEffect(()=> {

--- a/src/pages/feed/component/FeedDetail/FeedDetail.jsx
+++ b/src/pages/feed/component/FeedDetail/FeedDetail.jsx
@@ -75,13 +75,14 @@ const FeedDetail = ({ data, memberId }) => {
             const urls = await Promise.all(
                 attachments.map(async (attachment) => {
                     if(attachment.blurredFileUrl != null) {
-                        const url = attachment.blurredFileUrl;
+                        const url = { type: "image", url: attachment.blurredFileUrl };
                         return { attachmentId : attachment.attachmentId, url }; // 블러 사진 적용 : url 그대로 가져오기
                     } else {
                         const url = await AttachmentGetter(attachment.attachmentId);
                         return { attachmentId: attachment.attachmentId, url };
                     }
-
+                    // const url = await AttachmentGetter(attachment.attachmentId);
+                    // return { attachmentId: attachment.attachmentId, url };
                 })
             );
             setAttachmentUrls(urls.filter(urlObj => urlObj.url)); // 유효한 URL만 설정

--- a/src/pages/feed/component/FeedDetail/FeedDetail.jsx
+++ b/src/pages/feed/component/FeedDetail/FeedDetail.jsx
@@ -74,8 +74,14 @@ const FeedDetail = ({ data, memberId }) => {
         const fetchAttachments = async () => {
             const urls = await Promise.all(
                 attachments.map(async (attachment) => {
-                    const url = await AttachmentGetter(attachment.attachmentId);
-                    return { attachmentId: attachment.attachmentId, url };
+                    if(attachment.blurredFileUrl != null) {
+                        const url = attachment.blurredFileUrl;
+                        return { attachmentId : attachment.attachmentId, url }; // 블러 사진 적용 : url 그대로 가져오기
+                    } else {
+                        const url = await AttachmentGetter(attachment.attachmentId);
+                        return { attachmentId: attachment.attachmentId, url };
+                    }
+
                 })
             );
             setAttachmentUrls(urls.filter(urlObj => urlObj.url)); // 유효한 URL만 설정

--- a/src/pages/feed/component/FeedDetail/FeedDetail.jsx
+++ b/src/pages/feed/component/FeedDetail/FeedDetail.jsx
@@ -171,6 +171,11 @@ const FeedDetail = ({ data, memberId }) => {
 
     return (
         <div className="container">
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '10px' }}>
+                <Button variant="secondary" onClick={()=>goToBuildingProfile(buildingId)}>
+                    해당 건물 프로필로 이동
+                </Button>
+            </div>
             <Card>
                 <CardBody>
                     {/* Header */}

--- a/src/pages/feed/component/FeedForm/FeedForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedForm.jsx
@@ -38,7 +38,7 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
     const [feedUpdateShow, setFeedUpdateShow] = useState(false);
 
     // navigator
-    const { goToFeedDetail } = navigator();
+    const { goToFeedDetail, backHistory } = navigator();
 
     // 첨부파일을 삭제할 파일 목록
     const [deletedFiles, setDeletedFiles] = useState([]);
@@ -220,14 +220,16 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
     }
 
     const handleCancel = () => {
-        setFeedData({
-            title: '',
-            feedText: '',
-            tags: [],
-            category: 'GENERAL',
-            publicRange: 'PUBLIC',
-            attachments: []
-        });
+        // setFeedData({
+        //     title: '',
+        //     feedText: '',
+        //     tags: [],
+        //     category: 'GENERAL',
+        //     publicRange: 'PUBLIC',
+        //     attachments: []
+        // });
+
+        backHistory(); // 뒤로가기
     };
 
     const handleFileChange = (e) => {
@@ -391,7 +393,7 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                                 dateFormat="yyyy/MM/dd h:mm aa"
                                 showTimeSelect
                                 timeFormat="HH:mm"
-                                timeIntervals={15}
+                                timeIntervals={30}
                                 className="form-control"
                             />
                         </Form.Group>
@@ -406,7 +408,8 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                                 required
                             >
                                 <option value="PUBLIC">전체 공개</option>
-                                <option value="GROUP">그룹 공개</option>
+                                <option value="FOLLOWER_ONLY">팔로워 공개</option>
+                                <option value="MUTUAL_ONLY">맞팔 공개</option>
                                 <option value="PRIVATE">비공개</option>
                             </Form.Control>
                         </Form.Group>

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -168,6 +168,7 @@ const AppRoutes = () => {
             <Route path="form" element={<FeedForm />} /> {/* 일반 피드 추가 */}
             <Route path="voteForm" element={<FeedVoteForm />} /> {/* 투표 피드 추가 */}
             <Route path="form/:feedId" element={<FeedForm />} /> {/* 일반 피드 수정 */}
+            <Route path="megaphoneForm" element={<FeedMegaphoneForm />} /> {/* 확성기 피드 수정 */}
             <Route path="chart" element={<FeedChartPage />} />
             <Route path="main" element={<FeedListHomePage />}/>
             <Route path="" element={<FeedPages />} />


### PR DESCRIPTION
## 요약
통합 테스트 중 요구사항을 반영하고 버그를 수정했습니다.

## 변경 사항 설명
### 1. 테스트 중 불편한 부분 수정
다양한 버그 및 요구사항이 있었고, 이를 수정하고자 노력했습니다.

#### 1. 피드 취소 시, 뒤로 가기로 수정

#### 2. 피드 생성 시 공개 설정에 대한 버그 수정
설정에 오타가 있어서 변경하였습니다.
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/6b21ef31-6e9a-4ee8-ac0c-9643c52a8a81)
이제 다음과 같이 설정이 가능합니다.

#### 3. 확성기 피드 생성 버그 수정
`router`가 통합 중에 사라진 거 같아 다시 추가했습니다.
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/c617514b-233e-41de-b420-e1fa0006c2cf)

#### 4. 피드 상세보기에 피드 목록(건물 프로필)로 이동하는 버튼 추가
![240629_1](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/c4642e84-16b8-4211-bba8-2c90adf40bbc)
사실 밑줄의 부분이 같은 기능을 하는데, 가시성이 없어서 일단 버튼을 추가했습니다.

#### 5. 첨부파일 미리보기 수정
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/3b97b33a-0a4d-40ae-88db-89b6ad64290d)
Object Storage 설정을 변경해서 이제 잘 뜹니다.

#### 6. 블러 처리 사진 뜨기
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/a207fc41-8151-4e24-bea7-ff6174912595)
5. 와 연계되는 사항인데, 만약 DB(MySQL)에 `blurred_file_url`이 null이 아니라면, 그 url을 가져와서 전시합니다.

## 관련 이슈 및 참고 자료
없음
