### PR TITLE
fix : 피드 관련 세부 사항 변경

### DIFF
--- a/src/pages/feed/FeedBuildingListPage.jsx
+++ b/src/pages/feed/FeedBuildingListPage.jsx
@@ -99,11 +99,8 @@ const FeedBuildingListPage = () => {
     return (
         <div>
             <FeedDisplayBoard buildingId={buildingId} />
-            <br/>
             <FeedPopularyRanking buildingId={buildingId} />
-            <br/>
             <FeedCalendar memberId={memberId} buildingId={buildingId}/>
-            <br/>
             <div>
                 <div className="row">
                     {feeds.map((feed, index) => (

--- a/src/pages/feed/FeedListPage.jsx
+++ b/src/pages/feed/FeedListPage.jsx
@@ -64,8 +64,11 @@ const FeedListPage = ({toId}) => {
 
     // 랜더링 될 때마다 실행
     useEffect(() => {
+        console.log("page : " + page);
+        console.log("fetchUrl : " + fetchUrl);
         fetchData(fetchUrl, page);
-    }, [fetchUrl, page, fetchData]);
+
+    }, [page, fetchUrl, fetchData]);
 
     // 무한스크롤 구현 (IntersectionObserver)
     const lastFeedElementRef = useCallback((node) => {

--- a/src/pages/feed/component/FeedDetail/FeedDetail.jsx
+++ b/src/pages/feed/component/FeedDetail/FeedDetail.jsx
@@ -175,6 +175,8 @@ const FeedDetail = ({ data, memberId }) => {
     }
 
     const isPollCategory = feedCategory === 'POLL'; // 투표 카테고리에 대한 예외
+    const isEventCategory = feedCategory === 'EVENT'; // 이벤트 카테고리에 대한 예외
+    const isMegaphoneCategory = feedCategory === 'MEGAPHONE'; // 확성기 카테고리에 대한 예외
 
     return (
             <div>
@@ -184,9 +186,14 @@ const FeedDetail = ({ data, memberId }) => {
                         <span onClick={() => setFeedDeleteShow(true)}>
                             <MdDelete size='32'/> {/* 피드 삭제 : Modal 열기*/}
                         </span>
-                        <span onClick={() => goToFeedForm(writerId, feedId)}>
-                            <MdFeed size='32'/> {/* 피드 수정 */}
-                        </span>
+                        {/* 투표, 이벤트, 확성기는 수정 불가능 */}
+                        {( isPollCategory && isEventCategory && isMegaphoneCategory) ? (
+                            <span onClick={() => goToFeedForm(writerId, feedId)}>
+                                <MdFeed size='32'/> {/* 피드 수정 */}
+                            </span>
+                         ) : (
+                            <span></span>
+                         )}
                     </div>
                 )}
                 <div className={styles.iconRight}>

--- a/src/pages/feed/component/FeedList/FeedCalendar.jsx
+++ b/src/pages/feed/component/FeedList/FeedCalendar.jsx
@@ -84,7 +84,7 @@ const FeedCalendar = ({memberId, buildingId}) => {
 
   return (
     <div className='calendar-container'>
-      <h2 className='calender-title'>이벤트</h2>
+      <div className='calender-title'>이벤트</div>
       <DatePicker
         selected={selectedDate}
         onChange={handleDateChange}

--- a/src/pages/feed/component/FeedList/FeedItem.jsx
+++ b/src/pages/feed/component/FeedList/FeedItem.jsx
@@ -42,8 +42,8 @@ const FeedItem = ({ data, memberId }) => {
     const feedCategoryName = FeedCategoryGetter(feedCategory); // 카테고리 변환
     const isNoticeCategory = feedCategory === 'NOTICE'; // 공지 카테고리에 대한 예외
     const isPollCategory = feedCategory === 'POLL'; // 투표 카테고리에 대한 예외
-    const isEventCategory = feedCategory === 'EVENT';
-    const isMegaphoneCategory = feedCategory === 'MEGAPHONE';
+    const isEventCategory = feedCategory === 'EVENT'; // 이벤트 카테고리에 대한 예외
+    const isMegaphoneCategory = feedCategory === 'MEGAPHONE'; // 확성기 카테고리에 대한 예외
 
     const renderFeedText = (feedText) => renderFeedTextWithLink(feedText);
 
@@ -149,23 +149,26 @@ const FeedItem = ({ data, memberId }) => {
 
                     {/* footer */}
                     {/* 제목 : 공지라면 공지로 바로 리다이렉션한다.*/}
-                    {isNoticeCategory ? (
-                        <div className={styles.h2Like} onClick={() => goToDetailNotice(feedId)} style={{ cursor: 'pointer' }}>
-                            <FcApproval /> {title}
-                        </div>
-                    ) : (
-                        <div className={styles.h2Like} onClick={() => goToFeedDetail(memberId, feedId)} style={{ cursor: 'pointer' }}>
-                            {title}
-                        </div>
-                    )}
+                    <div onClick={() => goToDetailNotice(feedId)}>
+                        {isNoticeCategory ? (
+                            <div className={styles.h2Like} onClick={() => goToDetailNotice(feedId)} style={{ cursor: 'pointer' }}>
+                                <FcApproval /> {title}
+                            </div>
+                        ) : (
+                            <div className={styles.h2Like} onClick={() => goToFeedDetail(memberId, feedId)} style={{ cursor: 'pointer' }}>
+                                {title}
+                            </div>
+                        )}
 
-                    {/* 공지사항일 때는 내용을 출력하지 않는다. */}
-                    {isNoticeCategory ? '' : (
-                        <p className={styles.feedText}>{renderFeedText(feedText)}</p>
-                     )}
-                    <CardText>
-                        <small className={styles.textMuted}>{writtenTimeReplace}</small>
-                    </CardText>
+                        {/* 공지사항일 때는 내용을 출력하지 않는다. */}
+                        {isNoticeCategory ? '' : (
+                            <p className={styles.feedText} onClick={() => goToFeedDetail(memberId, feedId)}>{renderFeedText(feedText)}</p>
+                        )}
+
+                        <CardText>
+                            <small className={styles.textMuted}>{writtenTimeReplace}</small>
+                        </CardText>
+                    </div>
                 </CardBody>
             </Card>
         </div>

--- a/src/pages/feed/component/FeedList/FeedPopularyRanking.jsx
+++ b/src/pages/feed/component/FeedList/FeedPopularyRanking.jsx
@@ -46,7 +46,7 @@ const FeedPopularyRanking = ({buildingId}) => {
     return (
         <div className={styles.rankingContainer}>
             <Row className="justify-content-center my-4">
-                <h2 className={styles.rankingTitle}>인기 피드 랭킹</h2>
+                <div className={styles.rankingTitle}>인기 피드</div>
             </Row>
             <ListGroup as="ol">
                 {ranking.map((feed, index) => (

--- a/src/pages/feed/css/FeedList/FeedCalender.css
+++ b/src/pages/feed/css/FeedList/FeedCalender.css
@@ -49,4 +49,5 @@ p {
     margin-bottom: 10px;
     font-size: 24px;
     font-weight: bold;
+    color: inherit; /* Default color, inherits from parent */
 }

--- a/src/pages/feed/css/FeedList/FeedPopularyRanking.module.css
+++ b/src/pages/feed/css/FeedList/FeedPopularyRanking.module.css
@@ -7,6 +7,8 @@
     margin-bottom: 0px;
     font-size: 24px;
     font-weight: bold;
+    line-height: 1.2; /* Default line-height for <h2> */
+    color: inherit; /* Default color, inherits from parent */
 }
 
 .feedListItem {


### PR DESCRIPTION
## 요약
버그 및 세부사항 변경 내역입니다.

## 변경 사항 설명
### 1. 건물 피드 목록에 사라진 제목 설정
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/8276bd86-ed68-4469-a731-f4c10f84f753)
원래 항목마다 제목이 있었는데 이들이 사라져서 재설정 했습니다.

### 2. 확성기, 투표, 이벤트에 대한 수정 제한
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/2eedbaac-9805-4a4d-8abf-cb27ce307f80)
아직 수정에 대한 구현이 안되서 일단 막았습니다.
이벤트는 수정이 될탠데, 혹시나 모를 버그에 대비하여 수정 제한 리스트에 추가했습니다.

### 3. 피드 목록 클릭 범위 설정
![240701_1](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/4004ec2a-064a-4b03-b98d-f043285f3f19)
이제 제목과 더불어 내용을 클릭해도 피드 상세 보기로 이동합니다.

## 관련 이슈 및 참고 자료
없음
