### PR TITLE
fix: 채팅방 마커 안 사라지는 거 고침

### DIFF
--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -528,6 +528,9 @@ function fetchChatroomMarkers(navigate) {
         data.forEach((d) => {
           const chatroomId = d.chatroomId;
           chatroomMarkerCache.add(chatroomId);
+          if (popBuildingMarkers.has(chatroomId)) {
+            return;
+          }
           const contentHtml = getLiveliestChatroomMarkerHtml(d.chatroomName, d.liveliness);
           const chatroomMarker = addMarker(contentHtml, d.building.latitude, d.building.longitude);
           naver.maps.Event.addListener(chatroomMarker, "click", () => {


### PR DESCRIPTION
## 요약
건물명 보기 / 활발한 채팅방 보기 / 안 보기 ==> 각 모드 이동할 때 이전 모드의 마커는 사라져야 하는데 채팅방 마커가 안 사라지는 버그 고쳤습니다.

## 변경 사항 설명
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/c872eabe-1e12-4c90-8db5-74fc8335fcb8)
여기 이 버튼 누를 때 채팅방 마커 안 사라지고 갱신 안 되는 버그 고침


## 관련 이슈 및 참고 자료
Issue: #198