### PR TITLE
refactor: 건물 합치기 버튼 내 구독 목록 볼 땐 안 보이게 세팅

### DIFF
--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -211,7 +211,7 @@ export default function BMap() {
     <div className={mapStyles.mapContainer}>
       <div id="map">
         {
-          isSubscriptionView && (
+          isSubscriptionView && loginMember.memberId !== ownerIdOfMapInfo && (
             <Button
                 color="primary"
                 className={mapStyles.mapMergeButton}


### PR DESCRIPTION
## 요약
다른 사람 구독 목록을 볼 땐 건물 합치기 버튼이 보이지만 내 구독 목록을 볼 땐 건물 합치기 버튼이 보이지 않습니다.

## 변경 사항 설명
- 내 구독 목록 볼 땐 "건물 합치기" 버튼이 나타나지 않는다.

### 다른 사람의 구독 건물 조회할 때
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/2af44a5f-7111-4dd5-8b61-87f048753a65)

### 내 구독 건물 조회할 때
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/48a5fc2e-8fe4-41a4-8647-d1e71826b262)


※ URL 참고 - /map 의 subpath에 path variable이 있으면 그 회원의 구독 건물 조회임

## 관련 이슈 및 참고 자료

