### PR TITLE
design : overall design

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -17,7 +17,7 @@ const Header = ({ title }) => {
        { title }
       </div>
       <div>
-        <img src={`${process.env.PUBLIC_URL}/image/noon-mini-logo-removebg.png`} alt="Member Icon" style={styles.icon} />
+        <img src={`${process.env.PUBLIC_URL}/image/noon-mini-logo-removebg.png`} alt="NOON" style={styles.icon} />
       </div>
     </div>
   );

--- a/src/pages/CustomerSupport/AddReport.jsx
+++ b/src/pages/CustomerSupport/AddReport.jsx
@@ -1,122 +1,162 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import axiosInstance from '../../lib/axiosInstance';
-import Header from '../../components/common/Header'
+import Header from '../../components/common/Header';
 import Footer from '../../components/common/Footer';
 import MessageModal from './components/MessageModal';
 import messages from './metadata/messages';
 import { useSelector } from 'react-redux';
 import AlertModal from './components/AlertModal';
-import { CardHeader, CardTitle, Card, CardBody,Button } from 'reactstrap';
+import { CardHeader, Card, CardBody, Button } from 'reactstrap';
 import { CardFooter } from 'react-bootstrap';
+import '../CustomerSupport/css/add-report.css';
+import Swal from 'sweetalert2';
 
 const AddReport = () => {
-
   const member = useSelector((state) => state.auth.member);
   const { reporteeId } = useParams();
   const [reportText, setReportText] = useState('');
   const navigate = useNavigate();
-
+  const [activeTab, setActiveTab] = useState('guide'); // 'guide' for 신고안내, 'method' for 신고방법
 
   const handleReportTextChange = (e) => {
     setReportText(e.target.value);
   };
 
-
-  //신고 등록하기
+  // 신고 등록하기
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const addReport = async () => {
-
-    if(reportText==="" || null){
-      toggleNothingToAddModal();
+    if (reportText === "" || reportText === null) {
+      Swal.fire({
+        title: messages.nothingToAddRoport.title,
+        text: messages.nothingToAddRoport.description,
+        icon: 'warning',
+        confirmButtonText: 'OK'
+      });
       return;
     }
 
     try {
       const response = await axiosInstance.post(`/customersupport/addReport`, {
-        reporterId : member.memberId,
-        reporteeId : reporteeId,
-        reportText : reportText,
-        reportStatus : 'PEND'
+        reporterId: member.memberId,
+        reporteeId: reporteeId,
+        reportText: reportText,
+        reportStatus: 'PEND'
       });
-      console.log("등록한 신고 정보: "+JSON.stringify(response.data));
-      toggleReportModal();
+      console.log("등록한 신고 정보: " + JSON.stringify(response.data));
+      Swal.fire({
+        title: messages.addReport.title,
+        text: messages.addReport.description,
+        icon: 'success',
+        confirmButtonText: 'OK'
+      }).then(()=>{
+        navigate(-1)
+      });
+      return;
     } catch (error) {
       console.error("Error fetching addReport details:", error);
     }
-
   };
 
   const toggleReportModal = () => {
     setReportModalOpen(!reportModalOpen);
   };
 
-
-  //신고내용 미입력
+  // 신고내용 미입력
   const [nothingToAddModalOpen, setNothingToAddModalOpen] = useState(false);
   const toggleNothingToAddModal = () => {
-    setNothingToAddModalOpen(!reportModalOpen);
+    setNothingToAddModalOpen(!nothingToAddModalOpen);
   };
 
-
-
-
-
   return (
-
-
-
-    <div>
-
+    <div className>
       <Header title="신고하기" />
-
-
-      <Card style={{margin:'10px'}}>
-        <CardHeader>
-          <label htmlFor="reportedId">{reporteeId}를 신고합니다.</label>
-        </CardHeader>
-        <CardBody>
-          <div>
-              <textarea
-                id="reportText"
-                value={reportText}
-                onChange={handleReportTextChange}
-                placeholder="신고 사유를 상세히 작성..."
-                rows="10"
-                cols="50"
-              />
+      <div className="report-guide">
+        <div className="tabs">
+          <div
+            className={`tab ${activeTab === 'guide' ? 'active' : ''}`}
+            onClick={() => setActiveTab('guide')}
+          >
+            신고안내
           </div>
-        </CardBody>
-        <CardFooter>      
-          <Button 
-            color="" 
-            style={{ backgroundColor: '#030722', marginBottom: '0px', width: "100%", borderRadius: '50px', color: 'white' }} 
+          <div
+            className={`tab ${activeTab === 'method' ? 'active' : ''}`}
+            onClick={() => setActiveTab('method')}
+          >
+            신고하기
+          </div>
+        </div>
+        {activeTab === 'guide' && (
+          <div className="guide-content">
+            <h3>이럴 때 신고하세요!</h3>
+            <br />
+            <div className="guide-section">
+              <div className="guide-item">
+                <h4>피드/프로필</h4>
+                <ul>
+                  <li> - 음란성 내용</li>
+                  <li> - 저작권 위배</li>
+                  <li> - 상업적 게시물</li>
+                  <li> - 운영자를 사칭</li>
+                </ul>
+              </div>
+              <div className="guide-item">
+                <h4>채팅</h4>
+                <ul>
+                  <li> - 욕설/음란 메시지</li>
+                  <li> - 스팸/광고 메시지</li>
+                  <li> - 개인정보를 요구</li>
+                  <li> - 운영자를 사칭</li>
+                </ul>
+              </div>
+            </div>
+            <div className="caution">
+              <h4>주의사항</h4>
+              <p>신고하신 내용은 관리자가 프로필 및 게시글을 확인한 후 처리됩니다.</p>
+              <p>신고 내용에 따라 이용이 제한될 수 있으며 거짓 사실과 다르게 장난으로 신고할 경우 경고를 받을 수도 있습니다.</p>
+            </div>
+          </div>
+        )}
+
+        
+        {activeTab === 'method' && (
+
+        <div className="guide-content">
+
+          <h3>{reporteeId}를 신고합니다.</h3><br />
+
+        <Card>
+
+          <div className="guide-section">
+            <div className="guide-item">
+              <textarea
+              id="reportText"
+              value={reportText}
+              onChange={handleReportTextChange}
+              placeholder="신고 사유를 상세히 작성..."
+              rows="10"
+              cols="36"
+              style={{ border: 'none', outline: 'none' }}
+              />
+            </div>
+          </div>
+
+          <Button
+            color=""
+            style={{ backgroundColor: '#030722', marginBottom: '0px', width: "100%",  color: 'white' }}
             onClick={addReport}>
             신고하기
           </Button>  
-            <MessageModal isOpen={reportModalOpen} toggle={toggleReportModal} message={messages.addReport}/>
-            <AlertModal isOpen={nothingToAddModalOpen} toggle={toggleNothingToAddModal} message={messages.nothingToAddRoport}/>
-        </CardFooter>
-      </Card>
 
-      <div>
-          <div>
-          </div>
+        </Card>
 
+        </div>
+
+        )}
       </div>
-      <Footer />
+      
     </div>
   );
-};
-
-
-
-const styles = {
-  buttonContainer: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    marginTop: '20px',
-  },
 };
 
 export default AddReport;

--- a/src/pages/CustomerSupport/GetChatbot.jsx
+++ b/src/pages/CustomerSupport/GetChatbot.jsx
@@ -47,10 +47,10 @@ const GetChatbot = () => {
   return (
     <div className="chat-container">
       <Header title="NOON 챗봇" />
-      <div className="chat-body" ref={chatBodyRef}>
+      <div className="chat-body" ref={chatBodyRef} style={{marginBottom:'100px', width:'100%'}}>
         {messages.map(message => (
           <div key={message.id} className={`chat-message ${message.type}`}>
-            <div className="message-text">{message.text}</div>
+            <div className="message-text" dangerouslySetInnerHTML={{ __html: message.text }}></div>
             <div className="message-timestamp">{message.timestamp}</div>
           </div>
         ))}

--- a/src/pages/CustomerSupport/GetCustomerSupport.jsx
+++ b/src/pages/CustomerSupport/GetCustomerSupport.jsx
@@ -3,14 +3,20 @@ import CustomerSupportHeader from './components/CustomerSupportHeader';
 import Support from './components/Support';
 import Footer from '../../components/common/Footer';
 import Header from '../../components/common/Header';
+import BuildingChart from './components/BuildingChart';
+import { Row } from 'reactstrap';
 
 
 const GetCustomerSupport = () => {
   return (
     <div className="customer-support">
-         <Header title="고객 지원"/>
+        <Header title="고객 지원"/>
+
+        <Row style={{ textAlign: "center", margin: "0 auto", marginTop:'40px'}}>
+          <BuildingChart />
+        </Row>
+        
         <Support />
-        <Footer />
     </div>
   );
 };

--- a/src/pages/CustomerSupport/GetNotice.jsx
+++ b/src/pages/CustomerSupport/GetNotice.jsx
@@ -7,6 +7,8 @@ import messages from './metadata/messages';
 import { useSelector } from 'react-redux';
 import { Button, Card, CardHeader, CardBody, CardFooter, Row } from "reactstrap";
 import Header from '../../components/common/Header';
+import formatTime from '../CustomerSupport/util/FormatTime';
+
 
 const GetNotice = () => {
   const member = useSelector((state) => state.auth.member);
@@ -90,7 +92,7 @@ const GetNotice = () => {
     return <p>Loading...</p>;
   }
 
-    // 날짜 형식을 YYYY-MM-DD로 변환
+    // 날짜 형식을 YYYY-MM-DD로 변환 - Deprecated
     const formatDate = (dateString) => {
       const date = new Date(dateString);
       if (!isNaN(date.getTime())) {
@@ -114,7 +116,7 @@ const GetNotice = () => {
 
         <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
           <span style={{ color: 'gray', marginRight: '10px' }}>{notice.writerId}</span>
-          <span style={{ color: 'gray' }}>{formatDate(notice.writtenTime)}</span>
+          <span style={{ color: 'gray' }}>{formatTime(notice.writtenTime)}</span>
         </div>
         <Row className="row-margin-bottom feed-content">
         <div style={{ marginTop: '20px', lineHeight: '1.6' }} className="feed-content">

--- a/src/pages/CustomerSupport/GetNotice.jsx
+++ b/src/pages/CustomerSupport/GetNotice.jsx
@@ -70,8 +70,12 @@ const GetNotice = () => {
     if (notice) {
       const imgs = document.querySelectorAll('.feed-content img');
       const videos = document.querySelectorAll('.feed-content video');
+      const screenWidth = window.innerWidth;
 
       imgs.forEach(img => {
+        if (img.clientWidth < screenWidth) {
+        img.style.width = '100%';
+        } 
         img.style.maxWidth = '100%';
         img.style.height = 'auto';
         img.style.display = 'block';
@@ -79,6 +83,9 @@ const GetNotice = () => {
       });
 
       videos.forEach(video => {
+        if (video.clientWidth < screenWidth) {
+          video.style.width = '100%';
+        }
         video.style.maxWidth = '100%';
         video.style.height = 'auto';
         video.style.display = 'block';

--- a/src/pages/CustomerSupport/GetNoticeList.jsx
+++ b/src/pages/CustomerSupport/GetNoticeList.jsx
@@ -4,10 +4,10 @@ import axiosInstance from '../../lib/axiosInstance';
 import { Card, CardHeader, CardBody, Table, Row, Col, CardFooter } from 'reactstrap';
 import { useInView } from 'react-intersection-observer';
 import navigate from '../CustomerSupport/util/Navigator'
-
 import { useSelector } from 'react-redux';
 import '../building/css/tab-navigation.css';
 import Header from '../../components/common/Header';
+import formatTime from '../CustomerSupport/util/FormatTime';
 
 const GetNoticeList = () => {
   const [currentPage, setCurrentPage] = useState(0);
@@ -15,6 +15,7 @@ const GetNoticeList = () => {
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const { goToNoticeDetail, goToAddNotice } = navigate();
+
 
   // 회원 아이디(실제 데이터. 리덕스 상태값)
   const member = useSelector((state) => state.auth.member);
@@ -71,6 +72,7 @@ const GetNoticeList = () => {
     return 'Invalid Date';
   };
 
+
   // 새로운 공지인지 확인 (테스트를 위해 1시간 기준. 추후 1일이나 7일 기준으로 변경)
   const isNew = (dateString) => {
     const now = new Date();
@@ -117,7 +119,7 @@ const GetNoticeList = () => {
                     </div>
 
                     <div style={{ color: 'gray', fontSize: '12px' }}>
-                      {formatDate(maxNotice.writtenTime)}
+                      {formatTime(maxNotice.writtenTime)}
                     </div>
                   </div>
 
@@ -159,7 +161,7 @@ const GetNoticeList = () => {
 
                   
                     <div style={{ color: 'gray', fontSize: '12px' }}>
-                      {formatDate(notice.writtenTime)}
+                      {formatTime(notice.writtenTime)}
                     </div>
 
                   </div>

--- a/src/pages/CustomerSupport/components/BuildingChart.jsx
+++ b/src/pages/CustomerSupport/components/BuildingChart.jsx
@@ -1,30 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import axiosInstance from '../../../lib/axiosInstance';
-import { CardBody, CardFooter, CardTitle, Button, Card, ButtonGroup, Spinner } from 'reactstrap';
+import { CardBody, CardTitle, Button, Card, Spinner } from 'reactstrap';
+import '../css/building-chart.css';
 
 const BuildingChart = () => {
   const [cSelected, setCSelected] = useState([1]);
-
-  const [subscriberData, setSubscriberData] = useState([]);
-  const [feedData, setFeedData] = useState([]);
-  const [chatData, setChatData] = useState([]);
-  const [labels, setLabels] = useState([]);
   const [loading, setLoading] = useState(true);
-
   const [chartData, setChartData] = useState({
     labels: [],
     datasets: []
   });
-
-  const onCheckboxBtnClick = (selected) => {
-    const index = cSelected.indexOf(selected);
-    if (index < 0) {
-      setCSelected([...cSelected, selected]);
-    } else {
-      setCSelected(cSelected.filter(item => item !== selected));
-    }
-  };
 
   const fetchChartData = async (type) => {
     try {
@@ -49,23 +35,16 @@ const BuildingChart = () => {
     const feedResponse = cSelected.includes(2) ? await fetchChartData("FEED") : [];
     const chatResponse = cSelected.includes(3) ? await fetchChartData("CHAT") : [];
 
+
     const newLabels = subscriberResponse.length ? subscriberResponse.map(item => item.buildingId) :
                       feedResponse.length ? feedResponse.map(item => item.buildingId) :
                       chatResponse.length ? chatResponse.map(item => item.buildingId) : [];
-
-    setLabels(newLabels);
-
-    const newSubscriberData = subscriberResponse.map(item => item.cnt);
-    const newFeedData = feedResponse.map(item => item.cnt);
-    const newChatData = chatResponse.map(item => item.cnt);
-
     setChartData({
       labels: newLabels,
       datasets: [
         {
           label: '구독자 수',
-          data: newSubscriberData,
-          fill: false,
+          data: subscriberResponse.map(item => item.cnt),
           backgroundColor: 'rgba(75,192,192,0.4)',
           borderColor: 'rgba(75,192,192,1)',
           borderWidth: 2,
@@ -74,8 +53,7 @@ const BuildingChart = () => {
         },
         {
           label: '피드 수',
-          data: newFeedData,
-          fill: false,
+          data: feedResponse.map(item => item.cnt),
           backgroundColor: 'rgba(153,102,255,0.4)',
           borderColor: 'rgba(153,102,255,1)',
           borderWidth: 2,
@@ -84,8 +62,7 @@ const BuildingChart = () => {
         },
         {
           label: '채팅방 수',
-          data: newChatData,
-          fill: false,
+          data: chatResponse.map(item => item.cnt),
           backgroundColor: 'rgba(255,159,64,0.4)',
           borderColor: 'rgba(255,159,64,1)',
           borderWidth: 2,
@@ -95,35 +72,26 @@ const BuildingChart = () => {
       ]
     });
 
-    setSubscriberData(newSubscriberData);
-    setFeedData(newFeedData);
-    setChatData(newChatData);
     setLoading(false);
   };
-
-
-
-  
-
-  useEffect(() => {
-    updateChartData();
-  }, [cSelected]);
 
 
   useEffect(() => {
     if (cSelected.length === 0) {
       setCSelected([1]);
     }
+    updateChartData();
   }, [cSelected]);
-
 
   useEffect(() => {
     updateChartData();
   }, []);
 
-
-
-
+  const toggleSelected = async(index) => {
+    setCSelected(prevSelected =>
+      prevSelected.includes(index) ? prevSelected.filter(i => i !== index) : [...prevSelected, index]
+    );
+  };
 
   return (
     <div>
@@ -165,32 +133,26 @@ const BuildingChart = () => {
             </div>
           )}
         </CardBody>
-          <ButtonGroup>
-            <Button
-              color="primary"
-              outline
-              onClick={() => onCheckboxBtnClick(1)}
-              active={cSelected.includes(1)}
-            >
-              구독자 수
-            </Button>
-            <Button
-              color="primary"
-              outline
-              onClick={() => onCheckboxBtnClick(2)}
-              active={cSelected.includes(2)}
-            >
-              피드 수
-            </Button>
-            <Button
-              color="primary"
-              outline
-              onClick={() => onCheckboxBtnClick(3)}
-              active={cSelected.includes(3)}
-            >
-              채팅방 수
-            </Button>
-          </ButtonGroup>
+        <div className="button-group">
+          <div
+            className={`toggle-button ${cSelected.includes(1) ? 'active' : ''}`}
+            onClick={() => toggleSelected(1)}
+          >
+            구독자 수
+          </div>
+          <div
+            className={`toggle-button ${cSelected.includes(2) ? 'active' : ''}`}
+            onClick={() => toggleSelected(2)}
+          >
+            피드 수
+          </div>
+          <div
+            className={`toggle-button ${cSelected.includes(3) ? 'active' : ''}`}
+            onClick={() => toggleSelected(3)}
+          >
+            채팅방 수
+          </div>
+        </div>
       </Card>
     </div>
   );

--- a/src/pages/CustomerSupport/components/BuildingChart.jsx
+++ b/src/pages/CustomerSupport/components/BuildingChart.jsx
@@ -165,7 +165,6 @@ const BuildingChart = () => {
             </div>
           )}
         </CardBody>
-        <CardFooter>
           <ButtonGroup>
             <Button
               color="primary"
@@ -192,7 +191,6 @@ const BuildingChart = () => {
               채팅방 수
             </Button>
           </ButtonGroup>
-        </CardFooter>
       </Card>
     </div>
   );

--- a/src/pages/CustomerSupport/components/Support.jsx
+++ b/src/pages/CustomerSupport/components/Support.jsx
@@ -28,114 +28,100 @@ const Support = ({ isAdmin }) => {
       className="support-container"
       style={{ width: "100%", marginBottom:"25%", marginTop: "5%"}}
     >
-      <Row style={{ width: "100%", 
-              textAlign: "center",
-              margin: "0 auto",}}>
-        <BuildingChart />
-      </Row>
 
+      <div style={{width:'83%',margin: "0 auto", marginTop:'20px'}}>
       {role === "ADMIN" ? (
         <>
-          <Row
-            style={{
-              width: "100%",
-              justifyContent: "center",
-              marginTop:"10%",
-              marginBottom:"5%",
-              textAlign: "center",
-              margin: "0 auto",
-            }}
-          >
-            <Col>
-              <ClickableCard
-                path="./getNoticeList"
-                iconClass="nc-icon nc-vector text-danger"
-                category="공지 관리"
-                title={<i className="fas fa-bell"></i>}
-                onClick={handleCardClick}
-                active={activeCard === "./getNoticeList"}
-              />
-            </Col>
-            <Col>
-              <ClickableCard
-                path="./getReportList"
-                iconClass="nc-icon nc-favourite-28 text-primary"
-                category="신고 관리"
-                title={<i className="fa-solid fa-ban"></i>}
-                onClick={handleCardClick}
-                active={activeCard === "./getReportList"}
-              />
-            </Col>
-          </Row>
 
-          <Row
-            style={{
-              width: "100%",
-              justifyContent: "center",
-              marginBottom:"5%",
-              textAlign: "center",
-              margin: "0 auto",
-            }}
-          >
-            <Col>
+        <div style={{marginBottom:'15px'}}>
+          <ClickableCard
+              path="./getNoticeList"
+              iconClass="nc-icon nc-vector text-danger"
+              category="공지 관리"
+              title={<i className="fas fa-bell"></i>}
+              onClick={handleCardClick}
+              active={activeCard === "./getNoticeList"}
+            />
+        </div>
+
+        <div style={{marginBottom:'15px'}}>
+          <ClickableCard
+            path="./getReportList"
+            iconClass="nc-icon nc-favourite-28 text-primary"
+            category="신고 관리"
+            title={<i className="fa-solid fa-ban"></i>}
+            onClick={handleCardClick}
+            active={activeCard === "./getReportList"}
+          />
+        </div>
+
+        <div style={{marginBottom:'15px'}}>
+          <ClickableCard
+            path="./listImages"
+            iconClass="nc-icon nc-favourite-28 text-primary"
+            category="이미지 관리"
+            title={<i className="fas fa-exclamation-triangle"></i>}
+            onClick={handleCardClick}
+            active={activeCard === "./listImages"}
+          />
+          </div>
+
+          <div style={{marginBottom:'15px'}}>
+            <ClickableCard
+              path="./getChatbot"
+              iconClass="nc-icon nc-money-coins text-success"
+              category="NOON 챗봇"
+              title={<i className="fa-solid fa-headset"></i>}
+              onClick={handleCardClick}
+              active={activeCard === "./getChatbot"}
+            />
+          </div>
+
+          <div style={{marginBottom:'15px'}}>
+            <Link to={mainPageUrl} style={{textDecoration: 'none'}}>
               <ClickableCard
                 path="./listImages"
                 iconClass="nc-icon nc-favourite-28 text-primary"
-                category="이미지 관리"
-                title={<i className="fas fa-exclamation-triangle"></i>}
+                category="관리자 프로필"
+                title={<i class="fa-solid fa-user"></i>}
                 onClick={handleCardClick}
                 active={activeCard === "./listImages"}
               />
-            </Col>
-            <Col>
-              <Link to={mainPageUrl} style={{textDecoration: 'none'}}>
-                <ClickableCard
-                  path="./listImages"
-                  iconClass="nc-icon nc-favourite-28 text-primary"
-                  category="프로필"
-                  title={<i class="fa-solid fa-user"></i>}
-                  onClick={handleCardClick}
-                  active={activeCard === "./listImages"}
-                />
-              </Link>
-            </Col>
-          </Row>
+            </Link>
+          </div>
+
         </>
+
       ) : (
+
         <>
-          <Row
-            style={{
-              width: "100%",
-              justifyContent: "center",
-              marginTop:"10%",
-              marginBottom:"10%",
-              textAlign: "center",
-              margin: "0 auto",
-            }}
-          >
-            <Col>
-              <ClickableCard
-                path="./getNoticeList"
-                iconClass="nc-icon nc-globe text-warning"
-                category="공지사항 목록"
-                title={<i className="fas fa-bell"></i>}
-                onClick={handleCardClick}
-                active={activeCard === "./getNoticeList"}
-              />
-            </Col>
-            <Col>
-              <ClickableCard
-                path="./getChatbot"
-                iconClass="nc-icon nc-money-coins text-success"
-                category="NOON 챗봇"
-                title={<i className="fa-solid fa-headset"></i>}
-                onClick={handleCardClick}
-                active={activeCard === "./getChatbot"}
-              />
-            </Col>
-          </Row>
+
+        <div style={{marginBottom:'15px'}}>
+         <ClickableCard
+            path="./getNoticeList"
+            iconClass="nc-icon nc-globe text-warning"
+            category="공지사항 목록"
+            title={<i className="fas fa-bell"></i>}
+            onClick={handleCardClick}
+            active={activeCard === "./getNoticeList"}
+          />
+          </div>
+
+          <div style={{marginBottom:'15px'}}>
+            <ClickableCard
+              path="./getChatbot"
+              iconClass="nc-icon nc-money-coins text-success"
+              category="NOON 챗봇"
+              title={<i className="fa-solid fa-headset"></i>}
+              onClick={handleCardClick}
+              active={activeCard === "./getChatbot"}
+            />
+          </div>
+
         </>
       )}
+      </div>
+
     </Container>
   );
 };

--- a/src/pages/CustomerSupport/css/add-report.css
+++ b/src/pages/CustomerSupport/css/add-report.css
@@ -1,0 +1,80 @@
+.report-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 20px;
+  }
+  
+  .report-guide {
+    width: 100%;
+    max-width: 900px;
+    height: 800px;
+    margin-bottom: 70px;
+    padding: 20px;
+    border: 1px solid #ddd;
+    background-color: #f9f9f9;
+  }
+  
+  .tabs {
+    display: flex;
+    margin-bottom: 20px;
+  }
+  
+  .tab {
+    flex: 1;
+    padding: 10px;
+    text-align: center;
+    cursor: pointer;
+    background-color: #e9ecef;
+  }
+  
+  .tab.active {
+    background-color: #9BAAF8;
+    color: white;
+  }
+  
+  .guide-content {
+    padding: 20px;
+  }
+  
+  .guide-section {
+    display: flex;
+    justify-content: space-around;
+    margin-bottom: 20px;
+  }
+  
+  .guide-item {
+    flex: 1;
+    margin: 0 10px;
+  }
+  
+  .guide-item h4 {
+    margin-bottom: 10px;
+    color: #9BAAF8 ;
+  }
+  
+  .guide-item ul {
+    list-style: none;
+    padding: 0;
+  }
+  
+  .guide-item ul li {
+    margin-bottom: 5px;
+  }
+  
+  .caution {
+    background-color: #e9ecef;
+    padding: 10px;
+    border-radius: 5px;
+  }
+  
+  .caution h4 {
+    margin-bottom: 8px;
+    color: #fa5252;
+  }
+  
+  .caution p {
+    margin: 0;
+    ;
+  }
+  

--- a/src/pages/CustomerSupport/css/building-chart.css
+++ b/src/pages/CustomerSupport/css/building-chart.css
@@ -1,0 +1,20 @@
+.button-group {
+    display: flex;
+    justify-content: center;
+  }
+  
+  .toggle-button {
+    background-color: transparent;
+    border: 1px solid #9BAAF8;
+    color: #030722;
+    padding: 0.375rem 0.75rem;
+    width: 100%;
+  }
+  
+  .toggle-button.active {
+    background-color: #9BAAF8;
+    color: white;
+  }
+  
+
+  

--- a/src/pages/CustomerSupport/metadata/messages.js
+++ b/src/pages/CustomerSupport/metadata/messages.js
@@ -17,7 +17,7 @@ const messages = {
   },
     addReport: {
         title: '신고 등록 안내',
-        description: '신고가 등록되었습니다. 관리자 확인 후 알림을 드립니다.',
+        description: '신고가 등록되었습니다. 관리자 확인 후 문자를 드립니다.',
     },
     reportProcessing: {
         title: '신고 처리 안내',

--- a/src/pages/CustomerSupport/util/FormatTime.js
+++ b/src/pages/CustomerSupport/util/FormatTime.js
@@ -1,0 +1,26 @@
+const MINUTE = 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+const TEXT_MAX_LENGTH = 30;
+
+const formatTime = (dateString) => {
+
+    const writtenTime = new Date(dateString);
+    const periodInSeconds = (new Date() - writtenTime) / 1000;
+    let timeDisplay;
+  
+    if (periodInSeconds < MINUTE) {
+      timeDisplay = `${Math.round(periodInSeconds)}초 전`
+    } else if (periodInSeconds < HOUR) {
+      timeDisplay = `${Math.round(periodInSeconds / MINUTE)}분 전`
+    } else if (periodInSeconds < DAY) {
+      timeDisplay = `${Math.round(periodInSeconds / HOUR)}시간 전`
+    } else {
+      timeDisplay = `${writtenTime.getFullYear()}/${writtenTime.getMonth() + 1}/${writtenTime.getDate()}`
+    }
+
+    return timeDisplay;
+
+};
+
+export default formatTime;

--- a/src/pages/building/GetBuilding.jsx
+++ b/src/pages/building/GetBuilding.jsx
@@ -12,7 +12,6 @@ const Building = () => {
       <Header title="건물 프로필"/>
       <BuildingInfo subscriptionData={subscriptionData} setSubscriptionData={setSubscriptionData} />
       <TabNavigation subscriptionData={subscriptionData} />
-      <Footer/>
     </div>
   );
 };

--- a/src/pages/building/components/BuildingInfo.jsx
+++ b/src/pages/building/components/BuildingInfo.jsx
@@ -4,6 +4,7 @@ import axiosInstance from '../../../lib/axiosInstance';
 import { useSelector } from 'react-redux';
 import useMainPage from '../../member/hook/useMainPage';
 import { Link } from 'react-router-dom';
+import FeedDisplayBoard from '../../feed/component/FeedList/FeedDisplayBoard';
 
 import {
   Button,
@@ -166,14 +167,17 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
 
   return (
     <>  
+
+      <FeedDisplayBoard buildingId={buildingId} />
+
       <div className="content">
         <Row style={ {margin: "0 auto",marginTop:"20px", width: '95%', height: '90%' }} className="justify-content-center align-items-center">
           <Col md="4">
-            <Card className="card-user">
+            <Card className="card-user" style={{border:'3px solid #FFFFFD', marginBottom:'30px'}}>
               <div className="image"></div>
-
-              <CardTitle>{profile.buildingName}</CardTitle>
-              <CardText>{profile.roadAddr}</CardText>
+              <br/>
+              <CardTitle tag={"h3"}><b>&emsp;{profile.buildingName}</b></CardTitle>
+              <CardText>&emsp;{profile.roadAddr}</CardText>
 
               <Card style={{ width: "80%", margin: "0 auto", marginBottom: '20px'}}>
                 <CardBody>
@@ -184,7 +188,8 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                     block
                     style={{
                       backgroundColor: clickedButton === 'summary' ? '#f3f0ff' : '#9BAAF8',
-                      borderColor: '#9BAAF8'
+                      borderColor: '#9BAAF8',
+                      borderRadius:'8px'
                     }}
                     onClick={() => {
                       handleButtonClick('summary');
@@ -201,7 +206,7 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                 <div className="button-container">
                   <Row>
                     <Col className="ml-auto" lg="3" md="6" xs="6">
-                      <h5>
+                      <h5 style={{textAlign:'center'}}>
                         {subscriber} <br />
                         <small>구독자 수</small>
                       </h5>
@@ -211,18 +216,19 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                         block
                         style={{
                           backgroundColor: clickedButton === 'subscribe' ? '#f3f0ff' : '#9BAAF8',
-                          borderColor: '#9BAAF8'
+                          borderColor: '#9BAAF8',
+                          borderRadius: '50px'
                         }}
                         onClick={() => {
                           handleButtonClick('subscribe');
                           addOrDeleteSubscription();
                         }}
                       >
-                        {subscriptionData===true ? '구독취소' : '구독'}
+                        {subscriptionData===true ? '구독 취소' : '구독'}
                       </Button>
                     </Col>
                   </Row>
-                  <div style={{ overflowX: 'auto', whiteSpace: 'nowrap', marginTop: '10px' }}>
+                  <div style={{ overflowX: 'auto', whiteSpace: 'nowrap', marginTop: '10px', display: 'flex', justifyContent: 'center',}}>
                     {subscribers.map((subscriber, index) => (
                       <div 
                         key={subscriber.memberId} 
@@ -233,11 +239,10 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                           marginRight: '10px', 
                           border: '1px solid #ccc', 
                           padding: '10px', 
-                          borderRadius: '5px'
                         }}
                       >
                         <img
-                          src={subscriber.profilePhotoUrl}
+                          src={subscriber.profilePhotoUrl || '/image/defaultMemberProfilePhoto.png'}
                           alt={subscriber.nickname}
                           style={{
                             borderRadius: '50%',
@@ -253,26 +258,26 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                   </div>
 
                   {selectedMemberId && (
-                    <div style={styles.linkContainer}>
+                    <div style={{ display: 'flex', justifyContent: 'right', alignItems: 'center', marginTop: '10px' }}>
                       <Link to={mainPageUrl}>
-                        <button style={{backgroundColor: "#B8C6E3"}}>이 회원의 프로필 GO</button>
+                        <button style={{ backgroundColor: "#9BAAF8", width:'150px', height:'39px' ,borderRadius:'50px' }}>프로필로 이동</button>
                       </Link>
                     </div>
                   )}
-
                 </div>
               </CardFooter>
             </Card>
 
-            <Card style={{ width: "95%", margin: "0 auto", marginBottom: '20px'}}>
-              <CardTitle tag="h5">WIKI</CardTitle>
-              <CardText>건물 정보를 더 자세히 알아보세요!</CardText>
-              <CardFooter>
+            <Card style={{ width: "100%", margin: "0 auto", marginTop:'20px', marginBottom: '20px'}}>
+              <br/>
+              <CardTitle tag="h3"><b>&emsp;WIKI</b></CardTitle>
+              <CardText>&emsp;건물 정보를 더 자세히 알아보세요!</CardText>
+              
                 <Button
                   block
                   style={{
-                    backgroundColor: clickedButton === 'wiki' ? '#f3f0ff' : '#9BAAF8',
-                    borderColor: '#9BAAF8'
+                    backgroundColor: clickedButton === 'wiki' ? '#f3f0ff' : '#030722',
+                    borderColor: '#E8DEC9'
                   }}
                   onClick={() => {
                     handleButtonClick('wiki');
@@ -281,7 +286,6 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                 >
                   위키 보러가기
                 </Button>
-              </CardFooter>
             </Card>
           </Col>
         </Row>

--- a/src/pages/building/components/WantBuildingProfile.jsx
+++ b/src/pages/building/components/WantBuildingProfile.jsx
@@ -123,13 +123,15 @@ const WantBuildingProfile = ({ isOpen, onClose, applicationData }) => {
     <div style={styles.overlay}>
       <div style={styles.modal}>
         <div style={styles.popupHeader}>
-          <span role="img" aria-label="notification" style={styles.icon}>🔔</span>
-          <h2>건물 프로필 등록 신청</h2>
-          <i onClick={onClose} className="fa-solid fa-circle-xmark"></i>
+          <span role="img" aria-label="notification" style={styles.icon}>
+            <h3>🔔 건물 프로필 등록</h3>
+          </span>
+          <h4><i onClick={onClose} class="fa-solid fa-circle-xmark"></i></h4>
         </div>
-        <p>이 건물에서 일어나는 일을 알고 싶나요? 프로필 등록을 신청해보세요!</p>
+        <p>&emsp;이 건물에서 일어나는 일을 알고 싶나요? <br/> &emsp;프로필 등록을 신청해보세요!</p>
 
-        <Card>
+        <Card style={{paddingLeft:'20px', paddingRight:'20px'}}>
+          <br/>
           <h3>{buildingName}</h3>
           <p>{roadAddr}</p>
         </Card>
@@ -145,7 +147,7 @@ const WantBuildingProfile = ({ isOpen, onClose, applicationData }) => {
           {applicantList.map((applicant) => (
             <div key={applicant.memberId} onClick={() => setSelectedMemberId(applicant.memberId)}>
               <img
-                src={applicant.profilePhotoUrl}
+                src={applicant.profilePhotoUrl || '/image/defaultMemberProfilePhoto.png'}
                 alt={applicant.memberId}
                 style={styles.profilePhoto}
               />
@@ -185,8 +187,9 @@ const styles = {
     borderRadius: '10px',
     padding: '20px',
     boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
-    width: '300px',
+    width: '320px',
     position: 'relative',
+    border: '3px solid #D8B48B'
   },
   closeButton: {
     position: 'absolute',
@@ -213,7 +216,8 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: '10px',
+    marginTop:'25px',
+    marginBottom: '25px',
   },
   requestButton: {
     background: '#f0f0f0',


### PR DESCRIPTION
## 요약
전반적인 디자인 했습니다.

## 변경 사항 설명
시간 표현 수정(X분 전, X시간 전)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/4206c55d-0d3a-4047-b76e-b2977211f448)


 찌그러진 이미지 없도록 + 회원 이미지가 없는 것은 현준님의 default이미지 적용
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/0223e984-e000-4030-929c-75b9655527d7)


 신고하기, 신고처리 모달 Sweet Alert로 통일
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/52996a20-81b3-4d94-83a8-4298d9ce004a)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/4ff148e6-217d-4105-8329-2b3983b6fab8)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/8e3de0d7-00e6-4161-ab18-d39fa09bc3f6)


 Wiki div와 구독 div간격 주기
 건물 프로필 Card의 글자들이 너무 좌측 상단에 딱 붙지 않도록 간격 주기
 '위키 보러가기'버튼을 꽉 차게 수정(Footer안에 들어있는 느낌보다는 꽉 차게)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/99523b3e-2f66-4901-93e6-60d08d15b6f8)


 건물 등록 신청하기 모달 수정(타이틀사라짐, 신청하기 버튼이 위에 붙음, 각 글자별 간격)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/33daee93-8e4d-4693-9f7d-9f6bd65f2c4c)


 Support 컴포넌트의 버튼들과 차트 사이 간격 주기
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/67537115-d212-4b54-82a3-e6870db953f4)


 건물 정보 차트 버튼 클릭 및 효과 적용 수정
 건물 정보 차트 버튼 꽉 차게 수정
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/a213abe1-2fb5-44d3-a51e-33e01936524a)


 공지사항에서 첨부파일들 크기에 따라 스크롤 생기는 문제 (크기 통일)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/f67a7c6b-7410-4705-b331-92ca4c740f65)


#203 