### PR TITLE
refactor : hiddenSubscriptions

### DIFF
--- a/src/pages/building/components/BuildingInfo.jsx
+++ b/src/pages/building/components/BuildingInfo.jsx
@@ -28,8 +28,7 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
   const [selectedMemberId, setSelectedMemberId] = useState(null); 
   const mainPageUrl = useMainPage(selectedMemberId);
 
-  // 회원의 구독 여부
- // const [subscription, setSubscription] = useState(false);
+  const [hiddenSubscriptions, setHiddenSubscriptions] = useState(0);
 
   // 빌딩 아이디
   const { buildingId } = useParams();
@@ -69,12 +68,20 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
     console.log("구독자 수: " + response.data);
   };
 
-  //구독자 목록 가져오기 
+  //구독자 목록 가져오기 (공개범위에 따라 조회 가능한 구독자만 보여줌)
   const getSubscribers = async () => {
     const response = await axiosInstance.get(`/buildingProfile/getSubscribers`, {
-      params: { buildingId: buildingId }
+      params: { buildingId: buildingId, viewerId: member.memberId}
     });
-    setSubscribers(response.data);
+    if(response){
+      const visibleSubscribers = response.data.filter(member => member.visible);
+      const hiddenSubscribersCnt = response.data.length - visibleSubscribers.length;
+
+      setSubscribers(visibleSubscribers);
+      setHiddenSubscriptions(hiddenSubscribersCnt);
+      console.log("visibleSubscribers: "+visibleSubscribers);
+      console.log("hiddenSubscribersCnt: "+hiddenSubscribersCnt);
+    }
     console.log("구독자 목록: " + JSON.stringify(response.data));
   };
 
@@ -228,11 +235,11 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                       </Button>
                     </Col>
                   </Row>
-                  <div style={{ overflowX: 'auto', whiteSpace: 'nowrap', marginTop: '10px', display: 'flex', justifyContent: 'center',}}>
+                  <div style={{ alignItems: 'flex-end',overflowX: 'auto', whiteSpace: 'nowrap', marginTop: '10px',  justifyContent: 'center',}}>
                     {subscribers.map((subscriber, index) => (
                       <div 
-                        key={subscriber.memberId} 
-                        onClick={() => setSelectedMemberId(subscriber.memberId)}
+                        key={subscriber.member.memberId} 
+                        onClick={() => setSelectedMemberId(subscriber.member.memberId)}
                         style={{ 
                           display: 'inline-block', 
                           textAlign: 'center', 
@@ -252,9 +259,15 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                             margin: '0 auto',
                           }}
                         />
-                        <p style={{ margin: '5px 0 0 0' }}>{subscriber.nickname}</p>
+                        <p style={{ margin: '5px 0 0 0' }}>{subscriber.member.nickname}</p>
                       </div>
                     ))}
+                    
+                    {hiddenSubscriptions>0?
+                      <div style={{color:'#596079'}}>+ 숨은 구독자 {hiddenSubscriptions}명😜</div>
+                      :
+                      ""
+                    }
                   </div>
 
                   {selectedMemberId && (


### PR DESCRIPTION
## 요약
공개범위를 체크하여 구독자 목록을 볼 수 있게 했습니다. 

## 변경 사항 설명
공개범위를 체크하여 구독자 목록을 가져오도록 axios에서 viewerId를 넘겨주도록 수정했습니다.
'구독자 수'와 '구독자 목록'이 다른 점에서 사용자가 의아함을 느낄 수 있으므로
숨은 구독자 수도 표시를 해주었습니다. (맞팔공개인데 맞팔이 아닌, 팔로우 공개인데 팔로우가 아닌, 비공개인 구독자)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/7f5ed52d-88e3-4d15-a659-4616f0f10b8c)

'심오한이야기'회원은 구독목록 비공개 상태인데, 본인은 아래와 같이 구독자를 모두 조회할 수 있습니다.
맞팔공개/팔로우공개 등 조건에 맞는 회원도 아래처럼 조회가 가능합니다.
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/504c23ad-a963-49e6-a64d-592d53f79704)


## 관련 이슈 및 참고 자료
