### PR TITLE
feat: 프로필 사진 URL이 존재하지 않을 경우 기본 이미지로 대체

### DIFF
--- a/src/assets/css/module/map/BMap.css
+++ b/src/assets/css/module/map/BMap.css
@@ -24,20 +24,3 @@
   width: 20px;
   border: none;
 }
-
-.search-bar-container {
-  z-index: 95;
-  position: absolute;
-  top: 1%;
-  width: 90%;
-  margin-left: auto;
-  margin-right: auto;
-  left: 0;
-  right: 0;
-}
-
-.search-bar-container button {
-  margin: 0;
-  background-color: #9BAAF8;
-  border: none;
-}

--- a/src/assets/css/module/map/BMap.module.css
+++ b/src/assets/css/module/map/BMap.module.css
@@ -66,3 +66,20 @@
   top: 8%;
   left: 12px;
 }
+
+.searchBarContainer {
+  z-index: 95;
+  position: absolute;
+  top: 1%;
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+}
+
+.searchBarContainer button {
+  margin: 0;
+  background-color: #9BAAF8;
+  border: none;
+}

--- a/src/assets/css/module/search/Search.css
+++ b/src/assets/css/module/search/Search.css
@@ -1,12 +1,3 @@
-.search-container {
-  display: flex;
-  flex-direction: column;
-  height: 85vh;
-  width: 95%;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .list-container {
   display: flex;
   flex-direction: column;

--- a/src/assets/css/module/search/Search.module.css
+++ b/src/assets/css/module/search/Search.module.css
@@ -1,0 +1,22 @@
+.searchContainer {
+  display: flex;
+  flex-direction: column;
+  height: 85vh;
+  width: 95%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.searchBarContainer {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 12px;
+  margin-bottom: 0;
+}
+
+.searchBarContainer button {
+  margin: 0;
+  background-color: #9BAAF8;
+  border: none;
+}

--- a/src/assets/css/module/search/component/MemberSearchResult.module.css
+++ b/src/assets/css/module/search/component/MemberSearchResult.module.css
@@ -15,11 +15,13 @@
 
 .memberSearchProfileContainer {
   display: flex;
-  gap: 5px;
+  gap: 10px;
 }
 
 .memberSearchProfilePhoto {
   border-radius: 1000px;
+  width: 50px;
+  height: 50px;
 }
 
 .memberNameContainer {

--- a/src/components/common/SearchBar.jsx
+++ b/src/components/common/SearchBar.jsx
@@ -11,7 +11,7 @@ export const PARAM_KEY_SEARCH_KEYWORD = "search-keyword";
  * }} prop
  * @returns JSX.Element
  */
-export default function SearchBar({typeCallback, searchCallback, isSearchButtonEnabled = true}) {
+export default function SearchBar({typeCallback, searchCallback, className, isSearchButtonEnabled = true}) {
   const [queryParams, setQueryParams] = useSearchParams();
 
   const searchKeywordInputRef = useRef(null);
@@ -24,7 +24,7 @@ export default function SearchBar({typeCallback, searchCallback, isSearchButtonE
   }, []);
 
   return (
-    <InputGroup className="mb-3 search-bar-container">
+    <InputGroup className={`mb-3 ${className}`}>
       <Form.Control
           onChange={(e) => typeCallback(e.target.value)}
           ref={searchKeywordInputRef}

--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -262,6 +262,7 @@ export default function BMap() {
         <SearchBar
             typeCallback={(text) => setPlaceSearchKeyword(text)}
             searchCallback={() => searchPlaceList(placeSearchKeyword, onSearchPlace, queryParams, setQueryParams, setLoading, setPlacesSearchResultExists)}
+            className={mapStyles.searchBarContainer}
           />
         <button
             type="button"

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -10,11 +10,10 @@ import searchBuilding from "./axios/searchBuilding";
 import searchChatroom from "./axios/searchChatroom";
 import searchMember from "./axios/searchMember";
 import "../../assets/css/module/search/Search.css";
+import styles from "../../assets/css/module/search/Search.module.css";
 import { useSearchParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { Spinner } from "reactstrap";
-import { GoMoveToTop } from "react-icons/go";
-
 
 const PARAM_KEY_SEARCH_MODE = "search-mode";
 
@@ -153,11 +152,11 @@ export default function Search() {
   }
 
   return (
-    <div className="search-container">
+    <div className={styles.searchContainer}>
       <SearchBar typeCallback={(text) => {
         setSearchKeyword(text);
         search(text);
-      }} searchCallback={onSearchBtnClick} isSearchButtonEnabled={false} />
+      }} searchCallback={onSearchBtnClick} isSearchButtonEnabled={false} className={styles.searchBarContainer} />
       <SearchModeTab currentSearchMode={currentSearchMode} onModeChange={onModeChange} />
       {component}
       {loading && (

--- a/src/pages/search/axios/searchMember.js
+++ b/src/pages/search/axios/searchMember.js
@@ -7,7 +7,7 @@ export default function searchMember(searchKeyword, page, callback, requesterId)
       searchKeyword,
       page
     }
-  }).then((response) => callback(response.data.info.content));
+  }).then((response) => callback(response.data.info.content)).catch((err) => console.error(err));
 }
 
 export function isMemberSearchResultEmpty(data) {

--- a/src/pages/search/component/MemberSearchResult.jsx
+++ b/src/pages/search/component/MemberSearchResult.jsx
@@ -86,7 +86,16 @@ function MemberSearchResultItem({
       }
     >
       <div className={styles.memberSearchProfileContainer}>
-        <img className={styles.memberSearchProfilePhoto} src={profilePhotoUrl} alt="Profile" />
+        <img
+            className={styles.memberSearchProfilePhoto}
+            src={profilePhotoUrl || "/image/defaultMemberProfilePhoto.png"}
+            alt="Profile"
+            onError={(e) => {
+              e.currentTarget.onerror = null;
+              e.currentTarget.src = "/image/defaultMemberProfilePhoto.png";
+              console.log(e);
+            }}
+        />
         <div className={styles.memberNameContainer}>
           <div className={styles.nickname}>{abbreviateLongString(nickname, 14)}</div>
           <div className={styles.memberId}>{abbreviateLongString(memberId, 14)}</div>

--- a/src/pages/setting/MemberSetting.jsx
+++ b/src/pages/setting/MemberSetting.jsx
@@ -117,7 +117,7 @@ export default function MemberSetting() {
             <Spinner style={{ width: '3rem', height: '3rem' }} color="primary" />
           </div>
         ) : (
-          <main className="container member-setting-container">
+          <main className="container member-setting-container" style={{ marginTop: "24px" }}>
             <div className="setting-content-wrapper">
               {
                 COMPONENT_INFOS.map((data, idx) => (

--- a/src/pages/setting/css/MemberSetting.css
+++ b/src/pages/setting/css/MemberSetting.css
@@ -2,7 +2,6 @@
   width: 80%;
   display: flex;
   flex-direction: column;
-  margin-top: 24px;
 }
 
 .title-container {
@@ -49,13 +48,19 @@
 
 .setting-content {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
   gap: 6px;
   margin-left: 16px;
 }
 
 .setting-content * {
   margin: 0px;
+}
+
+.setting-content h3 {
+  font-size: 14px;
 }
 
 .btn--apply-setting {


### PR DESCRIPTION
## 요약
프로필 사진 URL이 null일 경우 기본 이미지로 대체함으로써 텅 빈 이미지를 노출하지 않는다.

## 변경 사항 설명
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/60085941/bb45badb-a465-45da-b20d-3b3ac50c17de)

## 관련 이슈 및 참고 자료
Issue: #223
