### PR TITLE
design : chatroomList

### DIFF
--- a/src/pages/building/components/BuildingInfo.jsx
+++ b/src/pages/building/components/BuildingInfo.jsx
@@ -249,8 +249,8 @@ const BuildingInfo = ({ subscriptionData, setSubscriptionData }) => {
                         }}
                       >
                         <img
-                          src={subscriber.profilePhotoUrl || '/image/defaultMemberProfilePhoto.png'}
-                          alt={subscriber.nickname}
+                          src={subscriber.member.profilePhotoUrl || '/image/defaultMemberProfilePhoto.png'}
+                          alt={subscriber.member.nickname}
                           style={{
                             borderRadius: '50%',
                             width: '50px',

--- a/src/pages/building/components/ChatroomList.jsx
+++ b/src/pages/building/components/ChatroomList.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import axiosInstance from '../../../lib/axiosInstance';
+import '../../feed/css/common/FeedNotFound.css';
+
 import {
   Card,
   CardHeader,
@@ -32,7 +34,7 @@ const ChatroomList = () => {
   };
 
   const handleChatroom = async (chatroomID) => {
-    navigate('../../chat/chatroom?chatroomID='+chatroomID)
+    navigate('../../chat/chatroom?chatroomID=' + chatroomID);
   }
 
   useEffect(() => {
@@ -40,18 +42,22 @@ const ChatroomList = () => {
   }, [buildingId]);
 
   return (
-    <div className="chatroom-list">
+    <div className="chatroom-list" style={{ marginBottom: '100px' }}>
 
-      <Card style={{marginBottom:'100px'}}>
-        <CardHeader>
-          채팅방 목록
-        </CardHeader>
-        <CardBody>
+      {chatroomList && chatroomList.length > 0 ? (
+        <>
+          <div className='chatroom-title' style={{
+            textAlign: 'center',
+            marginBottom: '10px',
+            fontSize: '24px',
+            fontWeight: 'bold',
+            color: 'inherit'
+          }}>
+            <i className="fa-solid fa-comments" /> 채팅방 목록
+          </div>
 
-
-        {chatroomList && chatroomList.length > 0 ? (
-          chatroomList.map((chatroom) => (
-            <Card key={chatroom.chatroomID}>
+          {chatroomList.map((chatroom) => (
+            <Card key={chatroom.chatroomID} style={{ marginTop: '20px' }}>
               <CardBody>
                 <Table responsive>
                   <tbody>
@@ -63,15 +69,17 @@ const ChatroomList = () => {
                 </Table>
               </CardBody>
             </Card>
-          ))
-        ) : (
-            <div colSpan="2" style={{ textAlign: 'center', fontSize: '20px', padding: '20px'}}>
-              <h3><FcAbout/> 아직 채팅방이 존재하지 않습니다!</h3> <br/>첫 번째 채팅방을 만들어보세요!
-            </div>
-        )}
+          ))}
+        </>
+      ) : (
 
-        </CardBody>
-      </Card>
+        <div className="not-found-container">
+          <h1 className='not-found-title'><FcAbout /> </h1>
+          <h1 className="not-found-title">채팅방이 없습니다!</h1>
+          <p className="not-found-message">새로운 채팅방을 만들어보세요 :D</p>
+        </div>
+
+      )}
 
     </div>
   );


### PR DESCRIPTION
## 요약
채팅방 목록, 채팅방이 없을 경우의 디자인을 피드 쪽에 맞춰 통일했습니다.
또한, 컨트롤러에서 구독자 목록을 넘겨주는 JSON데이터 구조가 바뀜에 따라, 건물 프로필에서 구독자 프로필 사진을 파싱하는 부분을 수정했습니다. (건물 프로필 구독자 이미지가 다시 제대로 보입니다.)

## 변경 사항 설명
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/6623292c-09b9-43a0-a1e5-0c4b220590bf)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/70474886/26d38d93-179e-42a1-a8c7-a4b79f01d9c6)

## 관련 이슈 및 참고 자료
