### PR TITLE
design : 디자인 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16781,7 +16781,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.9.0.tgz",
       "integrity": "sha512-mamNcaX9Ng+JeSbBu97nWwRhYvL2oba+xR2GxvyXsbDeGP+gkYIKZ+aDMMj/n20TbV9SCWm/H7nyuNTSiXA6yA==",
-      "license": "MIT",
       "dependencies": {
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.7.2"

--- a/src/pages/feed/component/FeedDetail/FeedDetail.jsx
+++ b/src/pages/feed/component/FeedDetail/FeedDetail.jsx
@@ -246,7 +246,7 @@ const FeedDetail = ({ data, memberId }) => {
                     { tags && tags.length > 0 && (
                         <div className="tags">
                             {tags.map((tag) => (
-                                    <Badge className='tag' key={tag.tagId} color="primary">
+                                    <Badge className={styles.tagBadge} key={tag.tagId} color="primary">
                                         {tag.tagText}
                                     </Badge>
                                 ))}

--- a/src/pages/feed/component/FeedForm/FeedForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Form, Button, Card, ListGroup, Badge, InputGroup } from 'react-bootstrap';
+import { Form, Button, ListGroup, Badge } from 'react-bootstrap';
 import axios_api from '../../../../lib/axios_api';
 import CheckModal from '../Common/CheckModal';
 import navigator from '../../util/Navigator';
@@ -7,6 +7,7 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css'; // 달력 전용 css;
 import styles from '../../css/FeedForm/FeedForm.module.css';
 import buttonStyles from '../../css/common/FeedButton.module.css';
+import { FaRegCalendarCheck } from "react-icons/fa";
 
 const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, onSave }) => {
     const [feedData, setFeedData] = useState({
@@ -294,7 +295,8 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                 </Form.Group>
                 <div className={styles.noticeBox}>
                     <span className={styles.noticeBoxText}>
-                        카테고리를 선택해 피드의 목적을 강조할 수 있습니다.
+                        카테고리를 선택해 피드의 목적을 강조할 수 있습니다.<br/>
+                        이벤트 피드는 생성 후 수정이 되지 않습니다.
                     </span>
                 </div>
                 <Form.Group controlId="feedTitle" className="mb-3">
@@ -380,16 +382,34 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                 </div>
                 {feedData.category === 'EVENT' && (
                 <Form.Group controlId="eventDate" className="mb-3">
-                    <Form.Label>이벤트 날짜 : </Form.Label>
-                    <DatePicker
-                        selected={eventDate}
-                        onChange={handleDateChange}
-                        dateFormat="yyyy/MM/dd h:mm aa"
-                        showTimeSelect
-                        timeFormat="HH:mm"
-                        timeIntervals={30}
-                        className="form-control"
-                    />
+                    <div className={styles.feedFormSubTitle}><FaRegCalendarCheck/> 특별한 날을 선택해주세요</div>
+                    <div className={styles.datePickerWrapper}>
+                        {/* <DatePicker
+                            selected={eventDate}
+                            onChange={handleDateChange}
+                            dateFormat="yyyy/MM/dd h:mm aa"
+                            showTimeSelect
+                            timeFormat="HH:mm"
+                            timeIntervals={30}
+                            className={`form-control ${styles.datePickerInput}`}
+                        /> */}
+                        <DatePicker
+                            selected={eventDate}
+                            onChange={handleDateChange}
+                            dateFormat="yyyy/MM/dd"
+                            className={`form-control ${styles.datePickerInput}`}
+                        />
+                        <DatePicker
+                            selected={eventDate}
+                            onChange={handleDateChange}
+                            showTimeSelect
+                            showTimeSelectOnly
+                            timeIntervals={30}
+                            timeCaption="Time"
+                            dateFormat="h:mm aa"
+                            className={`form-control ${styles.datePickerInput}`}
+                        />
+                    </div>
                 </Form.Group>
                 ) }
 

--- a/src/pages/feed/component/FeedForm/FeedForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedForm.jsx
@@ -292,7 +292,11 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                         <option value="HELP_REQUEST">도움 요청</option>
                     </Form.Control>
                 </Form.Group>
-
+                <div className={styles.noticeBox}>
+                    <span className={styles.noticeBoxText}>
+                        카테고리를 선택해 피드의 목적을 강조할 수 있습니다.
+                    </span>
+                </div>
                 <Form.Group controlId="feedTitle" className="mb-3">
                     <Form.Control
                         type="text"
@@ -368,7 +372,12 @@ const FeedForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, o
                         ))}
                     </ListGroup>
                 </Form.Group>
-
+                <div className={styles.noticeBox}>
+                    <span className={styles.noticeBoxText}>
+                        파일은 사진과 동영상을 여러 개 넣을 수 있습니다. <br/>
+                        하나의 파일 당 최대 100MB로 제한됩니다.
+                    </span>
+                </div>
                 {feedData.category === 'EVENT' && (
                 <Form.Group controlId="eventDate" className="mb-3">
                     <Form.Label>이벤트 날짜 : </Form.Label>

--- a/src/pages/feed/component/FeedForm/FeedMegaphoneForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedMegaphoneForm.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
-import { Button, Form, Card, Container } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 import axios_api from '../../../../lib/axios_api';
 import CheckModal from '../Common/CheckModal';
 import navigator from '../../util/Navigator'
-import { Label } from 'reactstrap';
 import styles from '../../css/FeedForm/FeedForm.module.css';
 // import renderFeedTextWithLink from '../../util/renderFeedTextWithLink';
 import buttonStyles from '../../css/common/FeedButton.module.css';
+import { IoWarning } from 'react-icons/io5';
+import { AiFillSound  } from "react-icons/ai";
 
 const FeedVoteForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, onSave }) => {
     const [feedData, setFeedData] = useState({
@@ -152,10 +153,14 @@ const FeedVoteForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedI
     return (
         <div className={styles.feedFormContainer}>
             <Form onSubmit={handleSubmit}>
-                <Label>확성기로 하고 싶은 말을 작성하세요!</Label>
+                <div className={styles.noticeBox}>
+                    <span className={styles.noticeBoxText}>
+                        <IoWarning/> 확성기는 생성 후 수정이 되지 않습니다.
+                    </span>
+                </div>
+                <div className={styles.feedFormTitle}><AiFillSound/> 확성기로 하고 싶은 말을 작성하세요!</div>
                 {/* 내용 */}
                 <Form.Group controlId="feedText" className="mb-3">
-                    <Form.Label>내용</Form.Label>
                     <Form.Control
                         as="textarea"
                         name="feedText"

--- a/src/pages/feed/component/FeedForm/FeedVoteForm.jsx
+++ b/src/pages/feed/component/FeedForm/FeedVoteForm.jsx
@@ -6,7 +6,7 @@ import navigator from '../../util/Navigator'
 import VotePreview from './VotePreview';
 import styles from '../../css/FeedForm/FeedForm.module.css';
 import buttonStyles from '../../css/common/FeedButton.module.css';
-
+import { IoWarning } from "react-icons/io5";
 // import renderFeedTextWithLink from '../../util/renderFeedTextWithLink';
 
 const FeedVoteForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedId, onSave }) => {
@@ -212,6 +212,11 @@ const FeedVoteForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedI
     return (
         <div className={styles.feedFormContainer}>
             <Form onSubmit={handleSubmit}>
+                <div className={styles.noticeBox}>
+                    <span className={styles.noticeBoxText}>
+                        <IoWarning/> 투표 게시판은 생성 후 수정이 되지 않습니다.
+                    </span>
+                </div>
                 {/* 제목 */}
                 <Form.Group controlId="feedTitle" className="mb-3">
                     <Form.Control
@@ -274,6 +279,12 @@ const FeedVoteForm = ({ existingFeed, inputWriterId, inputBuildingId, inputFeedI
                 </Form.Group>
                 <hr/>
                 {/* 투표 생성*/}
+                <div className={styles.noticeBox}>
+                    <span className={styles.noticeBoxText}>
+                        투표를 생성해서 다양한 사람들의 의견을 들어보세요! <br/>
+                        투표 옵션을 추가하여 다양한 선택지를 만들 수 있습니다.
+                    </span>
+                </div>
                 <Form.Group className="mb-3">
                     <Form.Label>투표 질문</Form.Label>
                     <Form.Control

--- a/src/pages/feed/component/FeedList/FeedCalendar.jsx
+++ b/src/pages/feed/component/FeedList/FeedCalendar.jsx
@@ -23,13 +23,14 @@ const FeedCalendar = ({memberId, buildingId}) => {
 
         // 데이터 필터링 및 맵핑
         eventData.forEach(event => {
-            const dateKey = event.eventDate.split('T')[0];
+          const [dateKey, timeKey] = event.eventDate.split('T');
             if (!eventMap[dateKey]) {
               eventMap[dateKey] = [];
             }
             eventMap[dateKey].push({
               title: event.title,
               feedId: event.feedId,
+              time: timeKey.slice(0, 5)
             });
         });
 
@@ -99,7 +100,7 @@ const FeedCalendar = ({memberId, buildingId}) => {
             <ListGroup>
               {eventList.map((event, index) => (
                 <ListGroup.Item key={index} action onClick={() => handleEventClick(event.feedId)}>
-                  {event.title}
+                  {event.time} - {event.title}
                 </ListGroup.Item>
               ))}
             </ListGroup>

--- a/src/pages/feed/component/FeedList/FeedItem.jsx
+++ b/src/pages/feed/component/FeedList/FeedItem.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Image, Card, CardBody, CardImg, CardText } from 'react-bootstrap';
-import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark, FaBuilding, FaRegEye, FaCommentAlt } from 'react-icons/fa';
+import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark, FaBuilding, FaRegEye, FaCommentAlt, FaUserCheck } from 'react-icons/fa';
 import { toggleLike, toggleBookmark } from '../../axios/FeedAxios';
 import navigate from '../../util/Navigator'
 import renderFeedTextWithLink from '../../util/renderFeedTextWithLink';
@@ -34,6 +34,7 @@ const FeedItem = ({ data, memberId }) => {
         mainActivated,
         writtenTime,        // 포멧팅 처리
         feedAttachmentId,
+        recommendMember
     } = data;
 
     const [liked, setLiked] = useState(like);
@@ -92,6 +93,11 @@ const FeedItem = ({ data, memberId }) => {
 
     return (
         <div className={styles.feedItemContainer}>
+            {recommendMember && (
+                <div className={styles.recommendMember}>
+                    <FaUserCheck color="blue" size='20' /> {recommendMember} 님이 좋아하는 피드입니다.
+                </div>
+            )}
             <Card className={(isNoticeCategory ? styles.feedItemNotionColor : '') 
                 + (isEventCategory ? styles.feedItemEventColor : '')
                 + (isMegaphoneCategory ? styles.feedItemMegaphoneColor : '')}>

--- a/src/pages/feed/css/FeedForm/FeedForm.module.css
+++ b/src/pages/feed/css/FeedForm/FeedForm.module.css
@@ -67,3 +67,35 @@
     margin-left: 5px;
     cursor: pointer;
 }
+
+/* 주의사항 및 추가사항 스타일 */
+.noticeBox {
+    background-color: #f8f9fa; /* 연한 배경색 */
+    color: #7b7f81; /* 연한 글씨색 */
+    font-size: 0.875rem; /* 작은 글씨체 */
+    padding: 10px; /* 여백 */
+    border: 1px solid #e9ecef; /* 연한 테두리 */
+    border-radius: 4px; /* 둥근 모서리 */
+    margin-top: 10px; /* 상단 여백 */
+    margin-bottom: 10px; /* 하단 여백 */
+    display: flex;
+    align-items: center;
+}
+
+.noticeBoxIcon {
+    margin-right: 10px; /* 아이콘과 텍스트 사이 여백 */
+    color: #6c757d; /* 아이콘 색상 */
+}
+
+.noticeBoxText {
+    flex: 1; /* 텍스트가 남은 공간을 채우도록 설정 */
+    font-size: 0.875rem; /* 작은 글씨체 크기 */
+    line-height: 1.5; /* 줄 간격 */
+}
+
+/* 제목 스타일 */
+.feedFormTitle {
+    font-size: 1.2rem; /* 글씨 크기 */
+    text-align: center; /* 중앙 정렬 */
+    margin: 20px 0; /* 상하 여백 */
+}

--- a/src/pages/feed/css/FeedForm/FeedForm.module.css
+++ b/src/pages/feed/css/FeedForm/FeedForm.module.css
@@ -99,3 +99,22 @@
     text-align: center; /* 중앙 정렬 */
     margin: 20px 0; /* 상하 여백 */
 }
+
+.feedFormSubTitle {
+    font-size: 1.2rem; /* 글씨 크기 */
+    text-align: center; /* 중앙 정렬 */
+    margin: 10px 0; /* 상하 여백 */
+}
+
+/* DatePicker 스타일 */
+.datePickerWrapper {
+    display: flex;
+    gap: 10px; /* 요소 사이의 간격 */
+}
+
+.datePickerInput {
+    width: 100%;
+}
+
+/* text-align: center;
+width: 100%; */

--- a/src/pages/feed/css/common/FeedItemAndDetail.module.css
+++ b/src/pages/feed/css/common/FeedItemAndDetail.module.css
@@ -171,3 +171,15 @@
     padding: 0.5em 1em;
     color: white;
 }
+
+.recommendMember {
+    margin-top: 10px;
+    font-size: 14px;
+    color: #9BAAF8;
+    display: flex;
+    align-items: center;
+}
+
+.recommendMember svg {
+    margin-right: 5px;
+}

--- a/src/pages/feed/css/common/FeedItemAndDetail.module.css
+++ b/src/pages/feed/css/common/FeedItemAndDetail.module.css
@@ -160,3 +160,14 @@
     font-size: 13px;
     color: #888; /* 부드러운 회색 텍스트 색상 */
 }
+
+.tagBadge {
+    display: inline-flex;
+    align-items: center;
+    margin-bottom: 5px;
+    cursor: pointer;
+    background-color: #9BAAF8 !important; /* 배지 색상 변경 */
+    font-size: 0.9em; 
+    padding: 0.5em 1em;
+    color: white;
+}


### PR DESCRIPTION
## 요약
전체적인 세부 디자인을 수정했습니다.

## 변경 사항 설명
### 1. 추천 알고리즘 적용
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/39ce4221-6408-4b54-80fb-10012a36ca1f)
아무도 관심 없으셨겠지만 건물 프로필에는 피드 추천 알고리즘이 돌아가고 있었습니다.  
그래서 이를 티내기 위해 좌측 상단에 작게 내용을 추가했습니다.

### 2. 피드 작성 폼 수정
#### 1. 일반 피드 폼
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/b3afe597-f2b2-49ac-90a3-720db0e3f2a0)

#### 2. 투표 피드 폼
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/fe70c640-30fa-4a11-b948-d36eef8106f4)

#### 3. 확성기 피드 폼
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/0a2961eb-a70b-4fd2-b092-cbc2f55892f1)

대체로 주의 사항을 작성하고 제목 같은 경우는 가시성 좋게 개선했습니다.

### 3. 이벤트 피드 관련
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/b8d1b4c3-3ac9-486e-ac94-1eca657eff66)
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/a5dbfc67-c1b7-4981-a894-e9c9135a15b4)
달력 작성 시 UI를 개선하고 목록에 시간이 같이 전시되도록 수정했습니다.

### 4. 기타
![image](https://github.com/kuberMAPtes/noon-main-client-server/assets/102120762/873f4e56-68f3-44af-be17-ff79b039f59e)
피드 상세 보기에 태그 모양을 수정했습니다.

## 관련 이슈 및 참고 자료
#208 에서 계속 수정 중입니다.
