### PR TITLE
fix: 건물 등록됐는데 새로고침 안 하면 계속 등록되지 않은 건물 뜨는 버그

### DIFF
--- a/src/pages/map/BMap.jsx
+++ b/src/pages/map/BMap.jsx
@@ -484,11 +484,14 @@ async function fetchSubscriptions(memberId, navigate, setWantBuildingProfileModa
         return;
       }
       buildingMarkersCache.add(buildingId);
-      if (buildingSubscriptionMarkers.has(buildingId)) {
+      if (buildingSubscriptionMarkers.has(buildingId)
+          && d.building.profileActivated
+          && !buildingSubscriptionMarkers.get(buildingId).profileActivated) {
         return;
       }
       const contentHtml = getSubscriptionMarkerHtml(d.subscriptionProvider.nickname, d.building.buildingName, d.building.profileActivated);
       const buildingMarker = addMarker(contentHtml, d.building.latitude, d.building.longitude);
+      buildingMarker.profileActivated = d.building.profileActivated;
       naver.maps.Event.addListener(buildingMarker, "click", () => {
         if (d.building.profileActivated) {
           navigate(`/getBuildingProfile/${buildingId}`);


### PR DESCRIPTION
## 요약
건물 등록됐는데 새로고침 안 하면 계속 등록되지 않은 건물 뜨는 버그

## 변경 사항 설명
이제 건물 등록하고 다른 사람이 건물 등록하면 맵 드래그만 해도 등록되지 않은 건물 마커가 등록된 건물 마커로 바뀝니다.

## 관련 이슈 및 참고 자료
Issue: #234
