### PR TITLE
Refactor: 잔버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "framer-motion": "^11.2.11",
         "jquery": "^3.7.1",
         "js-cookie": "^3.0.5",
+        "lodash.debounce": "^4.0.8",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.2",
         "react-chartjs-2": "^5.2.0",
@@ -13680,7 +13681,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^11.2.11",
     "jquery": "^3.7.1",
     "js-cookie": "^3.0.5",
+    "lodash.debounce": "^4.0.8",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.2",
     "react-chartjs-2": "^5.2.0",

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -2,9 +2,14 @@ import React from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { useNavigate } from 'react-router-dom';
 
-const Header = ({ title }) => {
+const Header = ({ title,setIsSafeNavigation }) => {
   const navigate = useNavigate();
   const goBack = () => {
+    
+    if (typeof setIsSafeNavigation === 'function') {
+      setIsSafeNavigation(true);
+    }
+
     navigate(-1);
   };
 

--- a/src/pages/member/GetMember.jsx
+++ b/src/pages/member/GetMember.jsx
@@ -28,6 +28,7 @@ import NormalButton from "./component/NormalButton";
 import { navigateMainPage } from "../../util/mainPageUri";
 import useMainPage from "./hook/useMainPage";
 import Header from "../../components/common/Header";
+import { encryptWithLv } from "../../util/crypto";
 
 const GetMember = () => {
   // 각 필드의 상태와 유효성 메시지, 유효성 플래그 관리
@@ -63,8 +64,10 @@ const GetMember = () => {
   const handlePwdUpdateClick = () => {
     // alert("handleClick실행 :: "+isMemberIdValid);
     //휴대폰번호로 네비게이션
-    if (member.memberId) {
-      sessionStorage.setItem("w", memberId); // 세션 스토리지에 memberId 저장
+    if (member?.memberId) {
+      const {encryptedData,ivData} = encryptWithLv(member?.memberId);
+      sessionStorage.setItem("encryptedDataUpdate",encryptedData); // 세션 스토리지에 memberId 저장
+      sessionStorage.setItem("ivDataUpdate",ivData)
       navigate("/member/addPhoneNumberAuthentification/" + "updatePwd");
     }
   };

--- a/src/pages/member/GetMemberProfile.jsx
+++ b/src/pages/member/GetMemberProfile.jsx
@@ -35,18 +35,27 @@ const GetMemberProfile = () => {
   // const lastFeedElementRef = UseProfileInfiniteScroll(hasMore, setPage);
   const feedSectionRef = useRef(null);
 
+  const [isSafeNavigation,setIsSafeNavigation] = useState(false);//true로 바꿔야 뷰가 깨끗하게 네비게이션함.
+
+  if(isSafeNavigation){
+    return null;
+  }
+
   return (
     <>
-    <Header title={fromId===toId ? "내 프로필" : `${profile.nickname}님의 프로필`}/>
+    <Header
+    title={fromId===toId ? "내 프로필" : `${profile.nickname}님의 프로필`}
+    setIsSafeNavigation={setIsSafeNavigation}/>
     <Container
       fluid
       className={`${module.container} d-flex flex-column justify-content-start align-items-center pt-6`}
       style={{
         flexWrap: "no",
         paddingTop: "30px",
+        paddingBottom:"30px",
         margin: "0px",
         maxWidth: "100%",
-        height: "85vh",
+        height: "100%",
       }}
     >
       <Row
@@ -67,6 +76,7 @@ const GetMemberProfile = () => {
                 followerCount={followerCount}
                 followingCount={followingCount}
                 feedSectionRef={feedSectionRef}
+                setIsSafeNavigation={setIsSafeNavigation}
               />
             </Col>
             {/* <Col xs={12} sm={12} md={12} lg={12}>
@@ -79,7 +89,7 @@ const GetMemberProfile = () => {
           </>
         ) : (
           <>
-            <Col xs={12} sm={12} md={12} lg={12}>
+            <Col xs={12} sm={12} md={12} lg={12} style={{marginBottom:"10px"}}>
               <ProfileBody
                 toId={toId}
                 fromId={fromId}
@@ -90,9 +100,10 @@ const GetMemberProfile = () => {
                 followerCount={followerCount}
                 followingCount={followingCount}
                 feedSectionRef={feedSectionRef}
+                setIsSafeNavigation={setIsSafeNavigation}
               />
             </Col>
-            <Col xs={12} sm={12} md={12} lg={12}>
+            <Col xs={12} sm={12} md={12} lg={12} style={{marginBottom:"40px"}}>
               {/* <ProfileFeedList
             toId={toId}
             feeds={feeds}

--- a/src/pages/member/IdFormToUpdatePwd.jsx
+++ b/src/pages/member/IdFormToUpdatePwd.jsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { setFooterEnbaled } from "../../redux/slices/footerEnabledSlice";
 import useFooterToggle from "../../components/hook/useFooterToggle";
 import Header from "../../components/common/Header";
+import { encryptWithLv } from "../../util/crypto";
 const IdFormToUpdatePwd = () => {
   
   const [memberId, setMemberId] = useState("");
@@ -33,8 +34,9 @@ const IdFormToUpdatePwd = () => {
     // alert("handleClick실행 :: "+isMemberIdValid);
     setIsNavigating(true);
     if (isMemberIdValid) {
-      //휴대폰번호로 네비게이션
-      sessionStorage.setItem("w", memberId); // 세션 스토리지에 memberId 저장
+      const {encryptedData,ivData} = encryptWithLv(memberId);
+      sessionStorage.setItem("encryptedDataUpdate",encryptedData); // 세션 스토리지에 memberId 저장
+      sessionStorage.setItem("ivDataUpdate",ivData)
       navigate("/member/addPhoneNumberAuthentification/" + "updatePwd");
     } else {
       //alert("입력하신 아이디를 찾을 수 없습니다.");

--- a/src/pages/member/UpdatePwd.jsx
+++ b/src/pages/member/UpdatePwd.jsx
@@ -11,6 +11,7 @@ import useFooterToggle from "../../components/hook/useFooterToggle";
 import { useDispatch } from "react-redux";
 import { setFooterEnbaled } from "../../redux/slices/footerEnabledSlice";
 import Header from "../../components/common/Header";
+import { decryptWithLv } from "../../util/crypto";
 
 const UpdatePwd = () => {
   const [pwd, setPwd] = useState("");
@@ -32,11 +33,17 @@ const UpdatePwd = () => {
   const handleClick = async () => {
     if (isPwdValid && isPwdConfirmValid) {
       let result = "fail";
-      //alert("세션스토리지확인"+sessionStorage.getItem("w"));
-      const response = await updatePwd(sessionStorage.getItem("w"), pwd);
+      //alert("세션스토리지확인"+sessionStorage.getItem("encryptedDataUpdate"));
+      const encryptedData = sessionStorage.getItem("encryptedDataUpdate")
+      const ivData = sessionStorage.getItem("ivDataUpdate")
+      const memberId = decryptWithLv(encryptedData,ivData);
+      // console.log("memberId",memberId+"pwd"+pwd+"encryptedData"+encryptedData+"ivData"+ivData);
+      // alert("encryptedDataUpdate"+encryptedData+"ivData"+ivData+"memberId"+ memberId);
+      const response = await updatePwd(memberId, pwd);
 
       if (response) {
-        sessionStorage.removeItem("w");
+        sessionStorage.removeItem("encryptedDataUpdate");
+        sessionStorage.removeItem("ivDataUpdate");
         //alert("비밀번호 변경 성공");
         result = "success";
         navigate(`/member/updatePwdResult/${result}`);

--- a/src/pages/member/UpdatePwdResult.jsx
+++ b/src/pages/member/UpdatePwdResult.jsx
@@ -5,7 +5,7 @@ import "../../assets/css/module/member/base.module.css";
 import {motion} from "framer-motion";
 import styles from "../../assets/css/module/member/base.module.css";
 import useFooterToggle from "../../components/hook/useFooterToggle";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { setFooterEnbaled } from "../../redux/slices/footerEnabledSlice";
 const UpdatePwdResult = () => {
   const dispatch = useDispatch();
@@ -17,6 +17,7 @@ const UpdatePwdResult = () => {
   });
   const { result } = useParams();
   const navigate = useNavigate();
+  const member = useSelector((state)=>state.auth.member);
 
   return (
     <Container
@@ -32,6 +33,7 @@ const UpdatePwdResult = () => {
           {result === "fail" && (
             <h1 className="mb-4">비밀번호 변경에 실패하셨습니다.</h1>
           )}
+          {(!member || !member?.memberId) && (
               <div className="mt-4">
                 <motion.div
                   initial={{ opacity: 0 }}
@@ -49,6 +51,7 @@ const UpdatePwdResult = () => {
                   </Link>
                 </motion.div>
               </div>
+          )}
           
         </Col>
       </Row>

--- a/src/pages/member/component/LogoutForm.jsx
+++ b/src/pages/member/component/LogoutForm.jsx
@@ -11,7 +11,7 @@ import NormalButton from './NormalButton';
 import { showToast } from '../function/ToastNotification';
 
 
-const LogoutForm = () => {
+const LogoutForm = ({setIsSafeNavigation}) => {
   const dispatch = useDispatch();
 //   const authorization = useSelector((state) => state.auth.authorization);
   const navigate = useNavigate();
@@ -26,6 +26,7 @@ const LogoutForm = () => {
       }
 
       await dispatch(logout(navigate));
+      setIsSafeNavigation(true);
       showToast("success", "로그아웃 성공!");
       
     } catch (error) {

--- a/src/pages/member/component/NicknameInput.jsx
+++ b/src/pages/member/component/NicknameInput.jsx
@@ -46,7 +46,10 @@ const NicknameInput = ({
   }, [nickname]);
 
   return (
-    <Form.Group controlId="formNickname" className="mb-3">
+    <Form.Group
+    controlId="formNickname"
+    style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}
+    >
       <Form.Label
         style={{
           border: isNicknameValid && "#91a7ff",
@@ -79,6 +82,9 @@ const NicknameInput = ({
           padding: "0px",
           resize: "none", // 사용자에 의한 크기 조절 비활성화
           overflow: "hidden", // 스크롤 바 숨기기
+          outline: "none", // 포커스 시 테두리 제거
+          border: 'none',
+          width:"100%",
         }}
         onKeyDown={handleNicknameKeyDown}
         required

--- a/src/pages/member/component/profile/ProfileActions.jsx
+++ b/src/pages/member/component/profile/ProfileActions.jsx
@@ -22,7 +22,7 @@ import { RiCustomerServiceLine } from "react-icons/ri";
 import { AiFillAlert } from "react-icons/ai";
 import {chatRequest} from "../../../Chat/function/axios_api";
 import ChatRequestModal from "./ChatRequestModal";
-const ProfileActions = ({ toId, fromId}) => {
+const ProfileActions = ({ toId, fromId,setIsSafeNavigation}) => {
   const [showMenu, setShowMenu] = React.useState(false);
   const member = useSelector((state) => state.auth.member);
   const { encryptedData, ivData } = useEncryptId(member?.memberId);
@@ -122,14 +122,19 @@ const ProfileActions = ({ toId, fromId}) => {
                style={{width:"28%"}}>
                 <AnimatedDiv 
                 style={{ width: "100%" }}
-                onClick={() => navigate("/setting")}>
+                onClick={() => {
+                  setIsSafeNavigation(true);
+                  navigate("/setting")}}>
                   <IoSettingsOutline />
                   <span style={{ padding: "0px 5px 0px 2px" }}></span>환경설정
                   <span style={{ padding: "0px 5px 0px 2px" }}></span>
                 </AnimatedDiv>
                 <AnimatedDiv
                 style={{ width: "100%" }}
-                onClick={() => navigate("/customerSupport")}>
+                onClick={() => {
+                  setIsSafeNavigation(true);
+                  navigate("/customerSupport");
+                  }}>
                   <RiCustomerServiceLine />
                   <span style={{ padding: "0px 5px 0px 2px" }}></span>고객지원
                   <span style={{ padding: "0px 5px 0px 2px" }}></span>

--- a/src/pages/member/component/profile/ProfileBody.jsx
+++ b/src/pages/member/component/profile/ProfileBody.jsx
@@ -39,7 +39,8 @@ const ProfileBody = ({
   buildingSubscriptionCount,
   followerCount,
   followingCount,
-  feedSectionRef
+  feedSectionRef,
+  setIsSafeNavigation
 }) => {
   // const [dajungTemperature, setDajungTemperature] = useState("");
   const defaultPhotoUrl = `${process.env.PUBLIC_URL}/image/defaultMemberProfilePhoto.png`;
@@ -105,7 +106,9 @@ const ProfileBody = ({
             className="d-flex justify-content-start"
             style={{ position: "absolute", left: 0, top: 0, padding: 0 }}
           >
-            <LogoutForm />
+            <LogoutForm
+              setIsSafeNavigation={setIsSafeNavigation}
+            />
           </div>
 
         <Row className="mb-3 align-items-start" style={{margin:"0%"}}>
@@ -161,6 +164,7 @@ const ProfileBody = ({
                     fontSize: "15px",
                     fontWeight: "bold",
                     textAlign: "center",
+                    marginTop:"30%",
                   }}
                 >
                   {profile.nickname}
@@ -227,7 +231,10 @@ const ProfileBody = ({
           feedSectionRef={feedSectionRef}
         />
 
-        <ProfileActions toId={toId} fromId={fromId}/>
+        <ProfileActions
+        toId={toId}
+        fromId={fromId}
+        setIsSafeNavigation={setIsSafeNavigation}/>
       </Card.Body>
     </Card>
   );

--- a/src/pages/member/function/AddPhoneNumberAuthentificationUtil.js
+++ b/src/pages/member/function/AddPhoneNumberAuthentificationUtil.js
@@ -1,4 +1,4 @@
-import { encryptWithLv } from "../../../util/crypto";
+import { decryptWithLv, encryptWithLv } from "../../../util/crypto";
 import {
   checkPhoneNumber,
   checkPhoneNumberAndMemberId,
@@ -71,7 +71,14 @@ export const handlePhoneNumberChange = async (
         }
       }
     } else if (toUrl === "updatePwd") {
-      const memberId = sessionStorage.getItem("w");
+      const encryptedData = sessionStorage.getItem("encryptedDataUpdate");
+      const ivData = sessionStorage.getItem("ivDataUpdate");
+      const memberId = decryptWithLv(encryptedData, ivData);
+
+      // console.log("비번변경수행 ::"+encryptedData+"수행 :: "+ivData+" 수행 :: " + memberId);
+      // alert("비번변경수행 ::"+encryptedData+"수행 :: "+ivData+" 수행 :: " + memberId);
+
+
       const response = await checkPhoneNumberAndMemberId(
         memberId,
         formattedPhoneNumber

--- a/src/pages/member/function/memberAxios.js
+++ b/src/pages/member/function/memberAxios.js
@@ -8,7 +8,8 @@ export const sendAuthentificationNumber = async (phoneNumber) => {
     const response = await axiosInstance.get(`/member/sendAuthentificationNumber`, {
         params: { phoneNumber },
     });
-    // const response = { data: { info: 1234 } }; //이거랑 위에 주석 하고 위에 주석 풀자
+    // const response = { data: { info: 1234 } }; 
+    //위에 주석 풀고 그 위에 주석하기
     console.log("sendAuthentificationNumber 응답:", response.data);
     return response.data;
   } catch (error) {
@@ -35,7 +36,8 @@ export const confirmAuthentificationNumber = async (
     // if (authentificationNumber === "1234") {
     //   return { info: true };
     // }
-    // const response = { data: { info: false } }; //이거랑 위에 주석 하고 위에 주석 풀자
+    // const response = { data: { info: false } };
+    //이거랑 위에 주석 하고 위에 주석 풀자
     console.log("confirmAuthentificationNumber 응답:", response.data);
 
     return response.data;


### PR DESCRIPTION

## 요약
잔버그 수정

## 변경 사항 설명
1.
Header에 자연스럽게 뒤로가기할 수 있도록 수정. 기존의 것들에 영향을 주지
않음. 현재 모든 네비게이션이 자연스럽게 보여지지는 않는 상태임. 고치려면 하나하나 고쳐줘야함.
2.
세션스토리지에 암호화되지 않은 데이터 넣었던 로직 암호화하였음.
(아직 암호화하지 않은 데이터가 들어가는 경우가 조금 있음 - 후순위 리팩토링 대상)
3.
프로필 닉네임 뷰 수정, 자연스럽지 않게 뷰 전환되는 것 수정
4.
onChange로 서버에 요청을 보내는 로직에 debounce적용.
디바운스란, 이벤트가 실행되고 나서 이벤트가 멈추고  x초 후에 로직을
수행하도록 하는 것.

https://github.com/kuberMAPtes/noon-main-client-server/assets/74259564/03c81aa7-8a77-46bf-b3ba-329f94966321

사용자가 입력을 멈추면 0.01초 뒤에 결과를 가져오도록 하였음.
디바운스를 적용하기 전에는 IME로 인한 에러가 났었음. 
웃음꽃피>웃음꽃핀>웃음꽃피네 를 입력할때
[웃음꽃핀>웃음꽃피네]  이 과정에서 IME관련된 문제로 인해(자세히는 모름..) 웃음꽃피네, 웃음꽃피 이렇게 두가지 요청이 서버로 보내지고 결과적으로, "웃음꽃피네"를 입력했을때 웃음꽃피에 대해 유효성검사한 결과를 마지막에 받도록 되었음. lodash debounce로 입력을 멈추면 그 다음 입력 결과를 가져오도록 로직을 수정
## 관련 이슈 및 참고 자료
(작성한 이슈를 작성하고 추가로 이해를 위한 참고자료가 있다면 공유 부탁드립니다)
